### PR TITLE
Update libebml to 1.4.6 and libmatroska to 1.7.2

### DIFF
--- a/third-party/libebml/ebml/EbmlHead.h
+++ b/third-party/libebml/ebml/EbmlHead.h
@@ -46,6 +46,8 @@ DECLARE_EBML_MASTER(EbmlHead)
     EbmlHead(const EbmlHead & ElementToClone)  = default;
 
         EBML_CONCRETE_CLASS(EbmlHead)
+
+    bool SetSizeInfinite(bool finite = true) override { return !finite; }
 };
 
 } // namespace libebml

--- a/third-party/libebml/ebml/EbmlVersion.h
+++ b/third-party/libebml/ebml/EbmlVersion.h
@@ -42,7 +42,7 @@
 
 namespace libebml {
 
-#define LIBEBML_VERSION 0x010405
+#define LIBEBML_VERSION 0x010406
 
 extern const EBML_DLL_API std::string EbmlCodeVersion;
 extern const EBML_DLL_API std::string EbmlCodeDate;

--- a/third-party/libebml/src/EbmlCrc32.cpp
+++ b/third-party/libebml/src/EbmlCrc32.cpp
@@ -38,6 +38,8 @@
 #include "ebml/EbmlContexts.h"
 #include "ebml/MemIOCallback.h"
 
+#include <new>
+
 #ifdef WORDS_BIGENDIAN
 static constexpr uint32_t CRC32_INDEX(uint32_t c) { return c >> 24; }
 static constexpr uint32_t CRC32_SHIFTED(uint32_t c) { return c << 8; }

--- a/third-party/libebml/src/EbmlElement.cpp
+++ b/third-party/libebml/src/EbmlElement.cpp
@@ -36,6 +36,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <new>
 #include <stdexcept>
 #include <sstream>
 

--- a/third-party/libebml/src/EbmlMaster.cpp
+++ b/third-party/libebml/src/EbmlMaster.cpp
@@ -36,6 +36,7 @@
 
 #include <cassert>
 #include <algorithm>
+#include <iterator>
 
 #include "ebml/EbmlMaster.h"
 #include "ebml/EbmlStream.h"
@@ -444,8 +445,13 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
 
           if (UpperEltFound) {
             --UpperEltFound;
-            if (UpperEltFound > 0 || MaxSizeToRead <= 0)
+            if (UpperEltFound > 0)
               goto processCrc;
+            if (MaxSizeToRead <= 0) {
+              delete FoundElt;
+              FoundElt = nullptr;
+              goto processCrc;
+            }
             ElementLevelA = FoundElt;
           }
 
@@ -455,9 +461,20 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
 
       if (UpperEltFound > 0) {
         UpperEltFound--;
-        if (UpperEltFound > 0 || MaxSizeToRead <= 0)
+        if (UpperEltFound > 0)
           goto processCrc;
+        if (MaxSizeToRead <= 0) {
+          delete FoundElt;
+          FoundElt = nullptr;
+          goto processCrc;
+        }
         ElementLevelA = FoundElt;
+        if (IsFiniteSize() && ElementLevelA->IsFiniteSize()) {
+          if (ElementLevelA->GetEndPosition() > GetEndPosition()) {
+            goto processCrc; // found an upper element that ends after this, we were truncated
+          }
+          MaxSizeToRead = GetEndPosition() - ElementLevelA->GetEndPosition(); // even if it's the default value
+        }
         continue;
       }
 

--- a/third-party/libebml/src/EbmlString.cpp
+++ b/third-party/libebml/src/EbmlString.cpp
@@ -34,6 +34,7 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 #include <cassert>
+#include <new>
 #include <limits>
 
 #include "ebml/EbmlString.h"
@@ -142,23 +143,19 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
     return GetSize();
 
   if (GetSize() == 0) {
-    Value = "";
-    SetValueIsSet();
+    Value.clear();
+
   } else {
-    auto Buffer = (GetSize() + 1 < std::numeric_limits<std::size_t>::max()) ? new (std::nothrow) char[GetSize() + 1] : nullptr;
-    if (Buffer == nullptr) {
-      // unable to store the data, skip it
-      input.setFilePointer(GetSize(), seek_current);
-    } else {
-      input.readFully(Buffer, GetSize());
-      if (Buffer[GetSize()-1] != '\0') {
-        Buffer[GetSize()] = '\0';
-      }
-      Value = Buffer;
-      delete [] Buffer;
-      SetValueIsSet();
-    }
+    Value.resize(GetSize());
+    std::memset(&Value[0], 0, GetSize());
+    input.readFully(&Value[0], GetSize());
+
+    auto PosNull = Value.find('\0');
+    if (PosNull != std::string::npos)
+      Value.resize(PosNull);
   }
+
+  SetValueIsSet();
 
   return GetSize();
 }

--- a/third-party/libebml/src/EbmlUnicodeString.cpp
+++ b/third-party/libebml/src/EbmlUnicodeString.cpp
@@ -1,4 +1,4 @@
-#include "utf8-cpp/utf8/checked.h"/****************************************************************************
+/****************************************************************************
 ** libebml : parse EBML files, see http://embl.sourceforge.net/
 **
 ** <file/class description>
@@ -36,10 +36,14 @@
 */
 
 #include <cassert>
+#include <iterator>
 #include <limits>
+#include <new>
 
 #include "ebml/EbmlUnicodeString.h"
 
+// Diffractor patch: upstream uses <utf8/checked.h>; Diffractor vendors utfcpp under
+// Include/utf8-cpp, so include via that prefix (re-apply after libebml upgrades).
 #include "utf8-cpp/utf8/checked.h"
 
 namespace libebml {
@@ -308,23 +312,15 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
 
   if (GetSize() == 0) {
     Value = static_cast<UTFstring::value_type>(0);
-    SetValueIsSet();
-  } else {
-    auto Buffer = (GetSize() + 1 < std::numeric_limits<std::size_t>::max()) ? new (std::nothrow) char[GetSize()+1] : nullptr;
-    if (Buffer == nullptr) {
-      // impossible to read, skip it
-      input.setFilePointer(GetSize(), seek_current);
-    } else {
-      input.readFully(Buffer, GetSize());
-      if (Buffer[GetSize()-1] != 0) {
-        Buffer[GetSize()] = 0;
-      }
 
-      Value.SetUTF8(Buffer); // implicit conversion to std::string
-      delete [] Buffer;
-      SetValueIsSet();
-    }
+  } else {
+    std::string Buffer(static_cast<std::string::size_type>(GetSize()), static_cast<char>(0));
+    input.readFully(&Buffer[0], GetSize());
+
+    Value.SetUTF8(Buffer.c_str()); // Let conversion to std::string cut off at the first 0
   }
+
+  SetValueIsSet();
 
   return GetSize();
 }

--- a/third-party/libebml/src/EbmlVersion.cpp
+++ b/third-party/libebml/src/EbmlVersion.cpp
@@ -38,7 +38,7 @@
 
 namespace libebml {
 
-const std::string EbmlCodeVersion = "1.4.5";
+const std::string EbmlCodeVersion = "1.4.6";
 
 // Up to version 1.3.3 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to

--- a/third-party/libebml/src/IOCallback.cpp
+++ b/third-party/libebml/src/IOCallback.cpp
@@ -33,6 +33,7 @@
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
 
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -64,10 +65,17 @@ void IOCallback::readFully(void*Buffer,size_t Size)
   if(Buffer == nullptr)
     throw;
 
-  if(read(Buffer,Size) != Size) {
-    stringstream Msg;
-    Msg<<"EOF in readFully("<<Buffer<<","<<Size<<")";
-    throw runtime_error(Msg.str());
+  char *readBuf = static_cast<char *>(Buffer);
+  uint32_t readSize = static_cast<uint32_t>(std::min<size_t>(std::numeric_limits<uint32>::max(), Size));
+  while (readSize != 0) {
+    if(read(readBuf,readSize) != readSize) {
+      stringstream Msg;
+      Msg<<"EOF in readFully("<<Buffer<<","<<Size<<")";
+      throw runtime_error(Msg.str());
+    }
+    Size -= readSize;
+    readBuf += readSize;
+    readSize = static_cast<uint32_t>(std::min<size_t>(std::numeric_limits<uint32>::max(), Size));
   }
 }
 

--- a/third-party/libebml/src/platform/win32/WinIOCallback.cpp
+++ b/third-party/libebml/src/platform/win32/WinIOCallback.cpp
@@ -146,6 +146,9 @@ bool WinIOCallback::open(const wchar_t* Path, const open_mode aMode, DWORD dwFla
       assert(false);
   }
 
+  // Diffractor patch: always use the Unicode CreateFileW path. The upstream code branches
+  // on GetVersion() to fall back to an ANSI CreateFileA on Win9x; GetVersion() is deprecated
+  // (C4996 under /sdl) and Win9x is unsupported. Re-apply this after libebml upgrades.
   //if ((LONG)GetVersion() >= 0) {
     mFile = CreateFileW(Path, AccessMode, ShareMode, NULL, Disposition, dwFlags, NULL);
 //  } else {

--- a/third-party/libmatroska/matroska/FileKax.h
+++ b/third-party/libmatroska/matroska/FileKax.h
@@ -38,7 +38,7 @@
 //#include <vector>
 
 #include "matroska/KaxTypes.h"
-#include "ebml/IOCallback.h"
+#include <ebml/IOCallback.h>
 //#include "MainHeader.h"
 //#include "TrackType.h"
 //#include "StreamInfo.h"

--- a/third-party/libmatroska/matroska/KaxBlock.h
+++ b/third-party/libmatroska/matroska/KaxBlock.h
@@ -38,8 +38,8 @@
 #include <vector>
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlBinary.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlBinary.h>
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxTracks.h"
 #include "matroska/KaxDefines.h"
 
@@ -68,11 +68,12 @@ class MATROSKA_DLL_API DataBuffer {
     {
       if (bInternalBuffer)
       {
-        myBuffer = new (std::nothrow) binary[mySize];
-        if (myBuffer == nullptr)
-          bValidValue = false;
-        else
+        try {
+          myBuffer = new binary[mySize];
           memcpy(myBuffer, aBuffer, mySize);
+        } catch (const std::bad_alloc &) {
+          bValidValue = false;
+        }
       }
       else
         myBuffer = aBuffer;

--- a/third-party/libmatroska/matroska/KaxBlockData.h
+++ b/third-party/libmatroska/matroska/KaxBlockData.h
@@ -34,9 +34,9 @@
 #define LIBMATROSKA_BLOCK_ADDITIONAL_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlMaster.h"
-#include "ebml/EbmlUInteger.h"
-#include "ebml/EbmlSInteger.h"
+#include <ebml/EbmlMaster.h>
+#include <ebml/EbmlUInteger.h>
+#include <ebml/EbmlSInteger.h>
 #include "matroska/KaxDefines.h"
 #include "matroska/KaxBlock.h"
 

--- a/third-party/libmatroska/matroska/KaxCluster.h
+++ b/third-party/libmatroska/matroska/KaxCluster.h
@@ -36,7 +36,7 @@
 #define LIBMATROSKA_CLUSTER_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxTracks.h"
 #include "matroska/KaxBlock.h"
 #include "matroska/KaxCues.h"

--- a/third-party/libmatroska/matroska/KaxContexts.h
+++ b/third-party/libmatroska/matroska/KaxContexts.h
@@ -36,7 +36,7 @@
 #define LIBMATROSKA_CONTEXTS_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlElement.h"
+#include <ebml/EbmlElement.h>
 
 using namespace libebml;
 

--- a/third-party/libmatroska/matroska/KaxCues.h
+++ b/third-party/libmatroska/matroska/KaxCues.h
@@ -38,7 +38,7 @@
 #include <vector>
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxBlock.h"
 
 using namespace libebml;

--- a/third-party/libmatroska/matroska/KaxCuesData.h
+++ b/third-party/libmatroska/matroska/KaxCuesData.h
@@ -34,8 +34,8 @@
 #define LIBMATROSKA_CUES_DATA_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlUInteger.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlUInteger.h>
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxDefines.h"
 
 using namespace libebml;

--- a/third-party/libmatroska/matroska/KaxDefines.h
+++ b/third-party/libmatroska/matroska/KaxDefines.h
@@ -33,8 +33,8 @@
 #ifndef LIBMATROSKA_DEFINES_H
 #define LIBMATROSKA_DEFINES_H
 
-#include "ebml/EbmlVersion.h"
-#include "ebml/EbmlElement.h"
+#include <ebml/EbmlVersion.h>
+#include <ebml/EbmlElement.h>
 
 #if defined(HAVE_EBML2) || defined(HAS_EBML2)
 #define DEFINE_MKX_CONTEXT(a)                DEFINE_xxx_CONTEXT(a,EBML_SemanticGlobal)
@@ -62,6 +62,7 @@
 class MATROSKA_DLL_API x : public EbmlMaster { \
     public: x(EBML_EXTRA_PARAM); \
     x(const x & ElementToClone) :EbmlMaster(ElementToClone) {} \
+    bool SetSizeInfinite(bool finite = true) override { return !finite; } \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_MASTER_CONS(x)     DECLARE_MKX_CONTEXT(x) \
@@ -150,6 +151,7 @@ class MATROSKA_DLL_API x : public EbmlMaster { \
 class MATROSKA_DLL_API x : public EbmlMaster { \
     public: x(); \
     x(const x & ElementToClone) :EbmlMaster(ElementToClone) {} \
+    bool SetSizeInfinite(bool finite = true) override { return !finite; } \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_MASTER_CONS(x)     DECLARE_MKX_CONTEXT(x) \

--- a/third-party/libmatroska/matroska/KaxInfoData.h
+++ b/third-party/libmatroska/matroska/KaxInfoData.h
@@ -38,12 +38,12 @@
 #define LIBMATROSKA_INFO_DATA_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlUInteger.h"
-#include "ebml/EbmlFloat.h"
-#include "ebml/EbmlUnicodeString.h"
-#include "ebml/EbmlBinary.h"
-#include "ebml/EbmlDate.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlUInteger.h>
+#include <ebml/EbmlFloat.h>
+#include <ebml/EbmlUnicodeString.h>
+#include <ebml/EbmlBinary.h>
+#include <ebml/EbmlDate.h>
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxDefines.h"
 #include "matroska/KaxSemantic.h"
 

--- a/third-party/libmatroska/matroska/KaxSeekHead.h
+++ b/third-party/libmatroska/matroska/KaxSeekHead.h
@@ -36,9 +36,9 @@
 #define LIBMATROSKA_SEEK_HEAD_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlMaster.h"
-#include "ebml/EbmlBinary.h"
-#include "ebml/EbmlUInteger.h"
+#include <ebml/EbmlMaster.h>
+#include <ebml/EbmlBinary.h>
+#include <ebml/EbmlUInteger.h>
 #include "matroska/KaxDefines.h"
 
 using namespace libebml;

--- a/third-party/libmatroska/matroska/KaxSegment.h
+++ b/third-party/libmatroska/matroska/KaxSegment.h
@@ -36,7 +36,7 @@
 #define LIBMATROSKA_SEGMENT_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxDefines.h"
 
 using namespace libebml;

--- a/third-party/libmatroska/matroska/KaxSemantic.h
+++ b/third-party/libmatroska/matroska/KaxSemantic.h
@@ -34,14 +34,14 @@
 #define LIBMATROSKA_SEMANTIC_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlUInteger.h"
-#include "ebml/EbmlSInteger.h"
-#include "ebml/EbmlDate.h"
-#include "ebml/EbmlFloat.h"
-#include "ebml/EbmlString.h"
-#include "ebml/EbmlUnicodeString.h"
-#include "ebml/EbmlBinary.h"
-#include "ebml/EbmlMaster.h"
+#include <ebml/EbmlUInteger.h>
+#include <ebml/EbmlSInteger.h>
+#include <ebml/EbmlDate.h>
+#include <ebml/EbmlFloat.h>
+#include <ebml/EbmlString.h>
+#include <ebml/EbmlUnicodeString.h>
+#include <ebml/EbmlBinary.h>
+#include <ebml/EbmlMaster.h>
 #include "matroska/KaxDefines.h"
 
 using namespace libebml;
@@ -49,7 +49,7 @@ using namespace libebml;
 namespace libmatroska {
 DECLARE_MKX_BINARY (KaxSeekID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() <= 4;}
+  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 4;}
 };
 
 DECLARE_MKX_UINTEGER(KaxSeekPosition)
@@ -254,9 +254,13 @@ DECLARE_MKX_UINTEGER(KaxTrackFlagLacing)
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackMinCache)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault) override;
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackMaxCache)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault) override;
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackDefaultDuration)
@@ -337,6 +341,8 @@ public:
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackOverlay)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault) override;
 };
 
 DECLARE_MKX_UINTEGER(KaxCodecDelay)
@@ -877,18 +883,17 @@ DECLARE_MKX_BINARY (KaxTagBinary)
 };
 
 /**
- *The `TrackType` defines the type of each frame found in the Track.
-The value **SHOULD** be stored on 1 octet.
+ *The TrackType defines the type of each frame found in the Track. The value **SHOULD** be stored on 1 octet.
  */
 typedef enum {
   MATROSKA_TRACK_TYPE_VIDEO            = 0x1, // An image.
   MATROSKA_TRACK_TYPE_AUDIO            = 0x2, // Audio samples.
-  MATROSKA_TRACK_TYPE_COMPLEX          = 0x3, // A mix of different other TrackType. The codec needs to define how the `Matroska Player` should interpret such data.
+  MATROSKA_TRACK_TYPE_COMPLEX          = 0x3, // A mix of different other TrackType. The codec needs to define how the Matroska Player should interpret such data.
   MATROSKA_TRACK_TYPE_LOGO             = 0x10, // An image to be rendered over the video track(s).
   MATROSKA_TRACK_TYPE_SUBTITLE         = 0x11, // Subtitle or closed caption data to be rendered over the video track(s).
   MATROSKA_TRACK_TYPE_BUTTONS          = 0x12, // Interactive button(s) to be rendered over the video track(s).
-  MATROSKA_TRACK_TYPE_CONTROL          = 0x20, // Metadata used to control the player of the `Matroska Player`.
-  MATROSKA_TRACK_TYPE_METADATA         = 0x21, // Timed metadata that can be passed on to the `Matroska Player`.
+  MATROSKA_TRACK_TYPE_CONTROL          = 0x20, // Metadata used to control the player of the Matroska Player.
+  MATROSKA_TRACK_TYPE_METADATA         = 0x21, // Timed metadata that can be passed on to the Matroska Player.
 } MatroskaTrackType;
 
 /**
@@ -896,30 +901,14 @@ typedef enum {
  */
 typedef enum {
   MATROSKA_TRACK_ENCODING_COMP_NONE             = -1,
-  MATROSKA_TRACK_ENCODING_COMP_ZLIB             = 0, // zlib compression [@!RFC1950].
-  MATROSKA_TRACK_ENCODING_COMP_BZLIB            = 1, // bzip2 compression [@!BZIP2], **SHOULD NOT** be used; see usage notes.
-  MATROSKA_TRACK_ENCODING_COMP_LZO1X            = 2, // Lempel-Ziv-Oberhumer compression [@!LZO], **SHOULD NOT** be used; see usage notes.
-  MATROSKA_TRACK_ENCODING_COMP_HEADERSTRIP      = 3, // Octets in `ContentCompSettings` ((#contentcompsettings-element)) have been stripped from each frame.
+  MATROSKA_TRACK_ENCODING_COMP_ZLIB             = 0, // zlib compression (RFC1950).
+  MATROSKA_TRACK_ENCODING_COMP_BZLIB            = 1, // bzip2 compression (BZIP2) **SHOULD NOT** be used.
+  MATROSKA_TRACK_ENCODING_COMP_LZO1X            = 2, // Lempel-Ziv-Oberhumer compression (LZO) **SHOULD NOT** be used.
+  MATROSKA_TRACK_ENCODING_COMP_HEADERSTRIP      = 3, // Octets in ContentCompSettings ((#contentcompsettings-element)) have been stripped from each frame.
 } MatroskaTrackEncodingCompAlgo;
 
 /**
- *This `ChapterTranslate` applies to this chapter codec of the given chapter edition(s); see (#chapprocesscodecid-element).
- */
-typedef enum {
-  MATROSKA_CHAPTERTRANSLATECODEC_MATROSKA_SCRIPT  = 0, // Chapter commands using the Matroska Script codec.
-  MATROSKA_CHAPTERTRANSLATECODEC_DVD_MENU         = 1, // Chapter commands using the DVD-like codec.
-} MatroskaChapterTranslateCodec;
-
-/**
- *This `TrackTranslate` applies to this chapter codec of the given chapter edition(s); see (#chapprocesscodecid-element).
- */
-typedef enum {
-  MATROSKA_TRACKTRANSLATECODEC_MATROSKA_SCRIPT  = 0, // Chapter commands using the Matroska Script codec.
-  MATROSKA_TRACKTRANSLATECODEC_DVD_MENU         = 1, // Chapter commands using the DVD-like codec.
-} MatroskaTrackTranslateCodec;
-
-/**
- *Specify whether the video frames in this track are interlaced or not.
+ *Specifies whether the video frames in this track are interlaced.
  */
 typedef enum {
   MATROSKA_VIDEO_FLAGINTERLACED_UNDETERMINED     = 0, // Unknown status.
@@ -928,19 +917,19 @@ typedef enum {
 } MatroskaVideoFlagInterlaced;
 
 /**
- *Specify the field ordering of video frames in this track.
+ *Specifies the field ordering of video frames in this track.
  */
 typedef enum {
   MATROSKA_VIDEO_FIELDORDER_PROGRESSIVE      = 0, // Interlaced frames.
   MATROSKA_VIDEO_FIELDORDER_TOPFIELDFIRST    = 1, // Top field displayed first. Top field stored first.
   MATROSKA_VIDEO_FIELDORDER_UNDETERMINED     = 2, // Unknown field order.
   MATROSKA_VIDEO_FIELDORDER_BOTTOMFIELDFIRST = 6, // Bottom field displayed first. Bottom field stored first.
-  MATROSKA_VIDEO_FIELDORDER_BOTTOMFIELDSWAPPED = 9, // Top field displayed first. Fields are interleaved in storage with the top line of the top field stored first.
-  MATROSKA_VIDEO_FIELDORDER_TOPFIELDSWAPPED  = 14, // Bottom field displayed first. Fields are interleaved in storage with the top line of the top field stored first.
+  MATROSKA_VIDEO_FIELDORDER_TOPFIELDSWAPPED  = 9, // Top field displayed first. Fields are interleaved in storage with the top line of the top field stored first.
+  MATROSKA_VIDEO_FIELDORDER_BOTTOMFIELDSWAPPED = 14, // Bottom field displayed first. Fields are interleaved in storage with the top line of the top field stored first.
 } MatroskaVideoFieldOrder;
 
 /**
- *Stereo-3D video mode. There are some more details in (#multi-planar-and-3d-videos).
+ *Stereo-3D video mode. See (#multi-planar-and-3d-videos) for more details.
  */
 typedef enum {
   MATROSKA_VIDEO_STEREO_MONO             = 0,
@@ -961,12 +950,11 @@ typedef enum {
 } MatroskaVideoStereoMode;
 
 /**
- *Indicate whether the BlockAdditional Element with BlockAddID of "1" contains Alpha data, as defined by to the Codec Mapping for the `CodecID`.
-Undefined values **SHOULD NOT** be used as the behavior of known implementations is different (considered either as 0 or 1).
+ *Indicates whether the BlockAdditional element with BlockAddID of "1"     contains Alpha data as defined by the Codec Mapping for the CodecID.  Undefined values (i.e., values other than 0 or 1) **SHOULD NOT** be used, as the  behavior of known implementations is different.
  */
 typedef enum {
-  MATROSKA_VIDEO_ALPHAMODE_NONE             = 0, // The BlockAdditional Element with BlockAddID of "1" does not exist or **SHOULD NOT** be considered as containing such data.
-  MATROSKA_VIDEO_ALPHAMODE_PRESENT          = 1, // The BlockAdditional Element with BlockAddID of "1" contains alpha channel data.
+  MATROSKA_VIDEO_ALPHAMODE_NONE             = 0, // The BlockAdditional element with BlockAddID of "1" does not exist or **SHOULD NOT** be considered as containing such data.
+  MATROSKA_VIDEO_ALPHAMODE_PRESENT          = 1, // The BlockAdditional element with BlockAddID of "1" contains alpha channel data.
 } MatroskaVideoAlphaMode;
 
 /**
@@ -980,7 +968,7 @@ typedef enum {
 } MatroskaVideoOldStereoMode;
 
 /**
- *How DisplayWidth & DisplayHeight are interpreted.
+ *How DisplayWidth and DisplayHeight are interpreted.
  */
 typedef enum {
   MATROSKA_DISPLAY_UNIT_PIXELS           = 0,
@@ -991,7 +979,7 @@ typedef enum {
 } MatroskaVideoDisplayUnit;
 
 /**
- *Specify the possible modifications to the aspect ratio.
+ *Specifies the possible modifications to the aspect ratio.
  */
 typedef enum {
   MATROSKA_VIDEO_ASPECTRATIOTYPE_FREE_RESIZING    = 0,
@@ -1000,8 +988,7 @@ typedef enum {
 } MatroskaVideoAspectRatioType;
 
 /**
- *The Matrix Coefficients of the video used to derive luma and chroma values from red, green, and blue color primaries.
-For clarity, the value and meanings for MatrixCoefficients are adopted from Table 4 of ISO/IEC 23001-8:2016 or ITU-T H.273.
+ *The Matrix Coefficients of the video used to derive luma and chroma values from red, green, and blue color primaries. For clarity, the value and meanings for MatrixCoefficients are adopted from Table 4 of ITU-H.273.
  */
 typedef enum {
   MATROSKA_VIDEO_MATRIXCOEFFICIENTS_IDENTITY         = 0,
@@ -1050,8 +1037,7 @@ typedef enum {
 } MatroskaVideoRange;
 
 /**
- *The transfer characteristics of the video. For clarity,
-the value and meanings for TransferCharacteristics are adopted from Table 3 of ISO/IEC 23091-4 or ITU-T H.273.
+ *The transfer characteristics of the video. For clarity, the value and meanings for TransferCharacteristics are adopted from Table 3 of ITU-H.273.
  */
 typedef enum {
   MATROSKA_TRANSFER_RESERVED         = 0,
@@ -1076,8 +1062,7 @@ typedef enum {
 } MatroskaVideoTransferCharacteristics;
 
 /**
- *The colour primaries of the video. For clarity,
-the value and meanings for Primaries are adopted from Table 2 of ISO/IEC 23091-4 or ITU-T H.273.
+ *The color primaries of the video. For clarity, the value and meanings for Primaries are adopted from Table 2 of ITU-H.273.
  */
 typedef enum {
   MATROSKA_VIDEO_PRIMARIES_RESERVED         = 0,
@@ -1113,10 +1098,10 @@ typedef enum {
   MATROSKA_EMPHASIS_NO_EMPHASIS      = 0,
   MATROSKA_EMPHASIS_CD_AUDIO         = 1, // First order filter with zero point at 50 microseconds and a pole at 15 microseconds. Also found on DVD Audio and MPEG audio.
   MATROSKA_EMPHASIS_RESERVED         = 2,
-  MATROSKA_EMPHASIS_CCIT_J_17        = 3, // Defined in [@!ITU-J.17].
+  MATROSKA_EMPHASIS_CCIT_J_17        = 3, // Defined in (ITU-J.17).
   MATROSKA_EMPHASIS_FM_50            = 4, // FM Radio in Europe. RC Filter with a time constant of 50 microseconds.
   MATROSKA_EMPHASIS_FM_75            = 5, // FM Radio in the USA. RC Filter with a time constant of 75 microseconds.
-  MATROSKA_EMPHASIS_PHONO_RIAA       = 10, // Phono filter with time constants of t1=3180, t2=318 and t3=75 microseconds. [@!NAB1964]
+  MATROSKA_EMPHASIS_PHONO_RIAA       = 10, // Phono filter with time constants of t1=3180, t2=318 and t3=75 microseconds. (NAB1964)
   MATROSKA_EMPHASIS_PHONO_IEC_N78    = 11, // Phono filter with time constants of t1=3180, t2=450 and t3=50 microseconds.
   MATROSKA_EMPHASIS_PHONO_TELDEC     = 12, // Phono filter with time constants of t1=3180, t2=318 and t3=50 microseconds.
   MATROSKA_EMPHASIS_PHONO_EMI        = 13, // Phono filter with time constants of t1=2500, t2=500 and t3=70 microseconds.
@@ -1135,17 +1120,16 @@ typedef enum {
 } MatroskaTrackPlaneType;
 
 /**
- *A bit field that describes which Elements have been modified in this way.
-Values (big-endian) can be OR'ed.
+ *A bit field that describes which elements have been modified in this way. Values (big-endian) can be OR'ed.
  */
 typedef enum {
-  MATROSKA_CONTENTENCODINGSCOPE_BLOCK            = 1, // All frame contents, excluding lacing data.
-  MATROSKA_CONTENTENCODINGSCOPE_PRIVATE          = 2, // The track's private data.
-  MATROSKA_CONTENTENCODINGSCOPE_NEXT             = 4, // The next ContentEncoding (next `ContentEncodingOrder`. Either the data inside `ContentCompression` and/or `ContentEncryption`).
+  MATROSKA_CONTENTENCODINGSCOPE_BLOCK            = 0x1, // All frame contents, excluding lacing data.
+  MATROSKA_CONTENTENCODINGSCOPE_PRIVATE          = 0x2, // The track's CodecPrivate data.
+  MATROSKA_CONTENTENCODINGSCOPE_NEXT             = 0x4, // The next ContentEncoding (next ContentEncodingOrder; the data inside ContentCompression and/or ContentEncryption).
 } MatroskaContentEncodingScope;
 
 /**
- *A value describing what kind of transformation is applied.
+ *A value describing the kind of transformation that is applied.
  */
 typedef enum {
   MATROSKA_CONTENTENCODINGTYPE_COMPRESSION      = 0,
@@ -1157,19 +1141,19 @@ typedef enum {
  */
 typedef enum {
   MATROSKA_CONTENTENCALGO_NOT_ENCRYPTED    = 0, // The data are not encrypted.
-  MATROSKA_CONTENTENCALGO_DES              = 1, // Data Encryption Standard (DES) [@!FIPS.46-3].
-  MATROSKA_CONTENTENCALGO_3DES             = 2, // Triple Data Encryption Algorithm [@!SP.800-67].
-  MATROSKA_CONTENTENCALGO_TWOFISH          = 3, // Twofish Encryption Algorithm [@!Twofish].
-  MATROSKA_CONTENTENCALGO_BLOWFISH         = 4, // Blowfish Encryption Algorithm [@!Blowfish].
-  MATROSKA_CONTENTENCALGO_AES              = 5, // Advanced Encryption Standard (AES) [@!FIPS.197].
+  MATROSKA_CONTENTENCALGO_DES              = 1, // Data Encryption Standard (DES) (FIPS46-3).
+  MATROSKA_CONTENTENCALGO_3DES             = 2, // Triple Data Encryption Algorithm (SP800-67).
+  MATROSKA_CONTENTENCALGO_TWOFISH          = 3, // Twofish Encryption Algorithm (Twofish).
+  MATROSKA_CONTENTENCALGO_BLOWFISH         = 4, // Blowfish Encryption Algorithm (Blowfish).
+  MATROSKA_CONTENTENCALGO_AES              = 5, // Advanced Encryption Standard (AES) (FIPS197).
 } MatroskaContentEncodingAlgo;
 
 /**
  *The AES cipher mode used in the encryption.
  */
 typedef enum {
-  MATROSKA_AESSETTINGSCIPHERMODE_AES_CTR          = 1, // Counter [@!SP.800-38A].
-  MATROSKA_AESSETTINGSCIPHERMODE_AES_CBC          = 2, // Cipher Block Chaining [@!SP.800-38A].
+  MATROSKA_AESSETTINGSCIPHERMODE_AES_CTR          = 1, // Counter (SP800-38A)
+  MATROSKA_AESSETTINGSCIPHERMODE_AES_CBC          = 2, // Cipher Block Chaining (SP800-38A)
 } MatroskaAESSettingsCipherMode;
 
 /**
@@ -1190,10 +1174,7 @@ typedef enum {
 } MatroskaContentSigHashAlgo;
 
 /**
- *Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
-If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it **MUST NOT** have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
-If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
-    
+ *Indicates what type of content the ChapterAtom contains and might be skipped.     It can be used to automatically skip content based on the type.     If a ChapterAtom is inside a ChapterAtom that has a ChapterSkipType set, it     **MUST NOT** have a ChapterSkipType or have a ChapterSkipType with the same value as it's parent ChapterAtom. If the ChapterAtom doesn't contain a ChapterTimeEnd, the value of the ChapterSkipType is only valid until the next ChapterAtom with a ChapterSkipType value or the end of the file.     
  */
 typedef enum {
   MATROSKA_CHAPTERSKIPTYPE_NO_SKIPPING      = 0, // Content which should not be skipped.
@@ -1203,10 +1184,19 @@ typedef enum {
   MATROSKA_CHAPTERSKIPTYPE_NEXT_PREVIEW     = 4, // Preview of the next episode of the content, usually found around the end. It may contain spoilers the user wants to avoid.
   MATROSKA_CHAPTERSKIPTYPE_PREVIEW          = 5, // Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid.
   MATROSKA_CHAPTERSKIPTYPE_ADVERTISEMENT    = 6, // Advertisement within the content.
+  MATROSKA_CHAPTERSKIPTYPE_INTERMISSION     = 7, // A pause of content between main parts of the content.
 } MatroskaChapterSkipType;
 
 /**
- *Defines when the process command **SHOULD** be handled
+ *Contains the type of the codec used for processing.
+ */
+typedef enum {
+  MATROSKA_CHAPPROCESSCODECID_MATROSKA_SCRIPT  = 0, // Chapter commands using the Matroska Script codec.
+  MATROSKA_CHAPPROCESSCODECID_DVD_MENU         = 1, // Chapter commands using the DVD-like codec.
+} MatroskaChapProcessCodecID;
+
+/**
+ *Defines when the process command **SHOULD** be handled.
  */
 typedef enum {
   MATROSKA_CHAPPROCESSTIME_DURING           = 0,
@@ -1218,13 +1208,13 @@ typedef enum {
  *A number to indicate the logical level of the target.
  */
 typedef enum {
-  MATROSKA_TARGET_TYPE_COLLECTION       = 70, // The highest hierarchical level that tags can describe.
-  MATROSKA_TARGET_TYPE_EDITION          = 60, // A list of lower levels grouped together.
-  MATROSKA_TARGET_TYPE_ALBUM            = 50, // The most common grouping level of music and video (equals to an episode for TV series).
-  MATROSKA_TARGET_TYPE_PART             = 40, // When an album or episode has different logical parts.
-  MATROSKA_TARGET_TYPE_TRACK            = 30, // The common parts of an album or movie.
-  MATROSKA_TARGET_TYPE_SUBTRACK         = 20, // Corresponds to parts of a track for audio (like a movement).
   MATROSKA_TARGET_TYPE_SHOT             = 10, // The lowest hierarchy found in music or movies.
+  MATROSKA_TARGET_TYPE_SUBTRACK         = 20, // Corresponds to parts of a track for audio, such as a movement or scene in a movie.
+  MATROSKA_TARGET_TYPE_TRACK            = 30, // The common parts of an album or movie.
+  MATROSKA_TARGET_TYPE_PART             = 40, // When an album or episode has different logical parts.
+  MATROSKA_TARGET_TYPE_ALBUM            = 50, // The most common grouping level of music and video (e.g., an episode for TV series).
+  MATROSKA_TARGET_TYPE_EDITION          = 60, // A list of lower levels grouped together.
+  MATROSKA_TARGET_TYPE_COLLECTION       = 70, // The highest hierarchical level that tags can describe.
 } MatroskaTargetTypeValue;
 
 

--- a/third-party/libmatroska/matroska/KaxTracks.h
+++ b/third-party/libmatroska/matroska/KaxTracks.h
@@ -36,8 +36,8 @@
 #define LIBMATROSKA_TRACKS_H
 
 #include "matroska/KaxTypes.h"
-#include "ebml/EbmlMaster.h"
-#include "ebml/EbmlUInteger.h"
+#include <ebml/EbmlMaster.h>
+#include <ebml/EbmlUInteger.h>
 #include "matroska/KaxDefines.h"
 #include "matroska/KaxSemantic.h"
 

--- a/third-party/libmatroska/matroska/KaxTypes.h
+++ b/third-party/libmatroska/matroska/KaxTypes.h
@@ -35,7 +35,7 @@
 #define LIBMATROSKA_TYPES_H
 
 #include "matroska/KaxConfig.h"
-#include "ebml/EbmlTypes.h"
+#include <ebml/EbmlTypes.h>
 #include "matroska/c/libmatroska_t.h"
 
 namespace libmatroska {

--- a/third-party/libmatroska/matroska/KaxVersion.h
+++ b/third-party/libmatroska/matroska/KaxVersion.h
@@ -35,12 +35,12 @@
 
 #include <string>
 
-#include "ebml/EbmlConfig.h"
+#include <ebml/EbmlConfig.h>
 #include "matroska/KaxConfig.h"
 
 namespace libmatroska {
 
-#define LIBMATROSKA_VERSION 0x010701
+#define LIBMATROSKA_VERSION 0x010702
 
 extern const MATROSKA_DLL_API std::string KaxCodeVersion;
 extern const MATROSKA_DLL_API std::string KaxCodeDate;

--- a/third-party/libmatroska/matroska/c/libmatroska_t.h
+++ b/third-party/libmatroska/matroska/c/libmatroska_t.h
@@ -42,7 +42,7 @@
 #ifndef _LIBMATROSKA_T_H_INCLUDED_
 #define _LIBMATROSKA_T_H_INCLUDED_
 
-#include "ebml/c/libebml_t.h"
+#include <ebml/EbmlTypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/third-party/libmatroska/src/FileKax.cpp
+++ b/third-party/libmatroska/src/FileKax.cpp
@@ -34,8 +34,8 @@
 */
 //#include "StdInclude.h"
 #include "matroska/FileKax.h"
-#include "ebml/EbmlVersion.h"
-#include "ebml/EbmlContexts.h"
+#include <ebml/EbmlVersion.h>
+#include <ebml/EbmlContexts.h>
 //#include "Cluster.h"
 //#include "Track.h"
 //#include "Block.h"

--- a/third-party/libmatroska/src/KaxBlock.cpp
+++ b/third-party/libmatroska/src/KaxBlock.cpp
@@ -36,8 +36,8 @@
 
 //#include <streams.h>
 
-#include "ebml/MemReadIOCallback.h"
-#include "ebml/SafeReadIOCallback.h"
+#include <ebml/MemReadIOCallback.h>
+#include <ebml/SafeReadIOCallback.h>
 #include "matroska/KaxBlock.h"
 #include "matroska/KaxContexts.h"
 #include "matroska/KaxBlockData.h"
@@ -45,6 +45,30 @@
 #include "matroska/KaxDefines.h"
 
 namespace libmatroska {
+
+static inline unsigned EBMLCodecLength(binary buf) {
+  // TODO: use C23  stdc_leading_zeros_uc() as well as GCC/clang __builtin_clz()
+  // __builtin_clz(buf) - 23;
+  if (buf & 0x80)
+    return 1;
+  if (buf & 0x40)
+    return 2;
+  if (buf & 0x20)
+    return 3;
+  if (buf & 0x10)
+    return 4;
+  if (buf & 0x08)
+    return 5;
+  if (buf & 0x04)
+    return 6;
+  if (buf & 0x02)
+    return 7;
+  if (buf & 0x01)
+    return 8;
+  // invalid EBML coded length
+  throw SafeReadIOCallback::EndOfStreamX(0);
+};
+
 
 DataBuffer * DataBuffer::Clone()
 {
@@ -496,9 +520,9 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
       } else {
         // read the number of frames in the lace
         uint32 LastBufferSize = GetSize() - BlockHeadSize - 1; // 1 for number of frame
-        const uint8 FrameNum = Mem.GetUInt8(); // number of frames in the lace - 1
+        const unsigned FrameNum = Mem.GetUInt8(); // number of frames in the lace - 1
         // read the list of frame sizes
-        uint8 Index;
+        unsigned Index;
         int32 FrameSize;
         uint32 SizeRead;
         uint64 SizeUnknown;
@@ -533,7 +557,11 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
             for (Index=1; Index<FrameNum; Index++) {
               // get the size of the frame
               SizeRead = LastBufferSize;
-              FrameSize += ReadCodedSizeSignedValue(BufferStart + Mem.GetPosition(), SizeRead, SizeUnknown);
+              auto FrameSizeDiff = ReadCodedSizeSignedValue(BufferStart + Mem.GetPosition(), SizeRead, SizeUnknown);
+              if (FrameSizeDiff < 0 && FrameSize <= -FrameSizeDiff)
+                // invalid negative or 0 frame size
+                throw SafeReadIOCallback::EndOfStreamX(SizeRead);
+              FrameSize += FrameSizeDiff;
               if (!FrameSize || (static_cast<uint32>(FrameSize + SizeRead) > LastBufferSize))
                 throw SafeReadIOCallback::EndOfStreamX(SizeRead);
               SizeList[Index] = FrameSize;
@@ -582,7 +610,6 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
       if (Result != 5)
         throw SafeReadIOCallback::EndOfStreamX(0);
       binary *cursor = _TempHead;
-      binary *_tmpBuf;
       uint8 BlockHeadSize = 4;
 
       // update internal values
@@ -625,9 +652,9 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
         // read the number of frames in the lace
         const uint32 TotalLacedSize = GetSize() - BlockHeadSize - 1; // 1 for number of frame
         uint32 LastBufferSize = TotalLacedSize;
-        const uint8 FrameNum = _TempHead[0]; // number of frames in the lace - 1
+        const unsigned FrameNum = _TempHead[0]; // number of frames in the lace - 1
         // read the list of frame sizes
-        uint8 Index;
+        unsigned Index;
         uint32 FrameSize;
         uint32 SizeRead;
         uint64 SizeUnknown;
@@ -656,32 +683,55 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
             SizeList[Index] = LastBufferSize;
             break;
           case LACING_EBML:
-            SizeRead = LastBufferSize;
-            cursor = _tmpBuf = new binary[FrameNum*4]; /// \warning assume the mean size will be coded in less than 4 bytes
-            Result += input.read(cursor, FrameNum*4);
-            FrameSize = ReadCodedSizeValue(cursor, SizeRead, SizeUnknown);
-            if (FrameSize > TotalLacedSize)
-              throw SafeReadIOCallback::EndOfStreamX(0);
-            SizeList[0] = FrameSize;
-            cursor += SizeRead;
-            LastBufferSize -= FrameSize + SizeRead;
+          {
+            if (FrameNum == 0)
+              Index = 0;
+            else {
+              binary length_buf[8];
+              if (input.read(length_buf, 1) != 1)
+                throw SafeReadIOCallback::EndOfStreamX(0);
 
-            for (Index=1; Index<FrameNum; Index++) {
-              // get the size of the frame
-              SizeRead = LastBufferSize;
-              FrameSize += ReadCodedSizeSignedValue(cursor, SizeRead, SizeUnknown);
+              // get the length of the EBML coded value
+              SizeRead = EBMLCodecLength(length_buf[0]);
+              // read remaining needed bytes
+              if (SizeRead > 1 && input.read(&length_buf[1], SizeRead - 1) != SizeRead - 1)
+                throw SafeReadIOCallback::EndOfStreamX(0);
+
+              FrameSize = ReadCodedSizeValue(length_buf, SizeRead, SizeUnknown);
               if (FrameSize > TotalLacedSize)
                 throw SafeReadIOCallback::EndOfStreamX(0);
-              SizeList[Index] = FrameSize;
-              cursor += SizeRead;
+
+              FirstFrameLocation += SizeRead;
+              SizeList[0] = FrameSize;
               LastBufferSize -= FrameSize + SizeRead;
+
+              for (Index=1; Index<FrameNum; Index++) {
+                if (input.read(length_buf, 1) != 1)
+                  throw SafeReadIOCallback::EndOfStreamX(0);
+
+                // get the length of the EBML coded value
+                SizeRead = EBMLCodecLength(length_buf[0]);
+                // read remaining needed bytes
+                if (SizeRead > 1 && input.read(&length_buf[1], SizeRead - 1) != SizeRead - 1)
+                  throw SafeReadIOCallback::EndOfStreamX(0);
+
+                auto FrameSizeDiff = ReadCodedSizeSignedValue(length_buf, SizeRead, SizeUnknown);
+                if (FrameSizeDiff < 0 && FrameSize <= -FrameSizeDiff)
+                  // invalid negative or 0 frame size
+                  throw SafeReadIOCallback::EndOfStreamX(0);
+                FrameSize += FrameSizeDiff;
+                if (FrameSize > TotalLacedSize)
+                  throw SafeReadIOCallback::EndOfStreamX(0);
+
+                FirstFrameLocation += SizeRead;
+                SizeList[Index] = FrameSize;
+                LastBufferSize -= FrameSize + SizeRead;
+              }
             }
 
-            FirstFrameLocation += cursor - _tmpBuf;
-
             SizeList[Index] = LastBufferSize;
-            delete [] _tmpBuf;
             break;
+          }
           case LACING_FIXED:
             for (Index=0; Index<=FrameNum; Index++) {
               // get the size of the frame
@@ -705,6 +755,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
   } catch (SafeReadIOCallback::EndOfStreamX &) {
     SetValueIsSet(false);
 
+    ReleaseFrames();
     myBuffers.clear();
     SizeList.clear();
     Timecode           = 0;

--- a/third-party/libmatroska/src/KaxContexts.cpp
+++ b/third-party/libmatroska/src/KaxContexts.cpp
@@ -32,8 +32,8 @@
   \version \$Id: KaxContexts.cpp 640 2004-07-09 21:05:36Z mosu $
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
-#include "ebml/EbmlContexts.h"
-#include "ebml/EbmlHead.h"
+#include <ebml/EbmlContexts.h>
+#include <ebml/EbmlHead.h>
 #include "matroska/KaxContexts.h"
 #include "matroska/KaxBlock.h"
 #include "matroska/KaxCluster.h"

--- a/third-party/libmatroska/src/KaxCues.cpp
+++ b/third-party/libmatroska/src/KaxCues.cpp
@@ -35,7 +35,7 @@
 #include "matroska/KaxCues.h"
 #include "matroska/KaxCuesData.h"
 #include "matroska/KaxContexts.h"
-#include "ebml/EbmlStream.h"
+#include <ebml/EbmlStream.h>
 #include "matroska/KaxDefines.h"
 #include "matroska/KaxSemantic.h"
 

--- a/third-party/libmatroska/src/KaxSegment.cpp
+++ b/third-party/libmatroska/src/KaxSegment.cpp
@@ -33,7 +33,7 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 #include "matroska/KaxSegment.h"
-#include "ebml/EbmlHead.h"
+#include <ebml/EbmlHead.h>
 
 // sub elements
 #include "matroska/KaxCluster.h"

--- a/third-party/libmatroska/src/KaxSemantic.cpp
+++ b/third-party/libmatroska/src/KaxSemantic.cpp
@@ -225,8 +225,8 @@ DEFINE_SEMANTIC_ITEM(false, true, KaxFlagTextDescriptions)
 DEFINE_SEMANTIC_ITEM(false, true, KaxFlagOriginal)
 DEFINE_SEMANTIC_ITEM(false, true, KaxFlagCommentary)
 DEFINE_SEMANTIC_ITEM(true, true, KaxTrackFlagLacing)
-DEFINE_SEMANTIC_ITEM(true, true, KaxTrackMinCache)
-DEFINE_SEMANTIC_ITEM(false, true, KaxTrackMaxCache)
+DEFINE_SEMANTIC_ITEM(true, true, KaxTrackMinCache) // not supported
+DEFINE_SEMANTIC_ITEM(false, true, KaxTrackMaxCache) // not supported
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackDefaultDuration)
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackDefaultDecodedFieldDuration)
 DEFINE_SEMANTIC_ITEM(true, true, KaxTrackTimecodeScale)
@@ -244,7 +244,7 @@ DEFINE_SEMANTIC_ITEM(false, true, KaxCodecSettings) // not supported
 DEFINE_SEMANTIC_ITEM(false, false, KaxCodecInfoURL) // not supported
 DEFINE_SEMANTIC_ITEM(false, false, KaxCodecDownloadURL) // not supported
 DEFINE_SEMANTIC_ITEM(true, true, KaxCodecDecodeAll) // not supported
-DEFINE_SEMANTIC_ITEM(false, false, KaxTrackOverlay)
+DEFINE_SEMANTIC_ITEM(false, false, KaxTrackOverlay) // not supported
 DEFINE_SEMANTIC_ITEM(true, true, KaxCodecDelay)
 DEFINE_SEMANTIC_ITEM(true, true, KaxSeekPreRoll)
 DEFINE_SEMANTIC_ITEM(false, false, KaxTrackTranslate)
@@ -832,6 +832,16 @@ filepos_t KaxEncryptedBlock::RenderData(IOCallback & /* output */, bool /* bForc
   return 0;
 }
 
+filepos_t KaxTrackMinCache::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrackMaxCache::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
 filepos_t KaxTrackTimecodeScale::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
@@ -863,6 +873,11 @@ filepos_t KaxCodecDownloadURL::RenderData(IOCallback & /* output */, bool /* bFo
 }
 
 filepos_t KaxCodecDecodeAll::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrackOverlay::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
 }

--- a/third-party/libmatroska/src/KaxVersion.cpp
+++ b/third-party/libmatroska/src/KaxVersion.cpp
@@ -37,7 +37,7 @@
 
 namespace libmatroska {
 
-const std::string KaxCodeVersion = "1.7.1";
+const std::string KaxCodeVersion = "1.7.2";
 
 // Up to version 1.4.4 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to


### PR DESCRIPTION
## Summary

- update vendored libebml from 1.4.5 to 1.4.6
- update vendored libmatroska from 1.7.1 to 1.7.2
- keep the paired libraries aligned using the already-integrated `release/1.27.0` snapshots
- avoid bringing any other 1.27 application or dependency changes into the 1.26 codebase

## Validation

- clean `master` baseline: x64 Release build, 344 passed / 0 failed
- forced x64 Release rebuild of libebml: 0 errors, 2 existing Windows handle-cast warnings
- forced x64 Release rebuild of libmatroska: 0 errors, 0 warnings
- x64 Release solution relink: 0 errors
- fresh Win32 Release solution build: 0 errors
- updated x64 embedded tests: 344 passed / 0 failed
- verified both vendor directories exactly match `release/1.27.0`
- verified no tracked changes outside `third-party/libebml` and `third-party/libmatroska`

## Notes

`git diff --check` reports one trailing-whitespace line in the upstream-generated `KaxSemantic.h`. It is preserved intentionally so the vendored snapshot remains byte-for-byte identical to the validated 1.27 copy.