### PR TITLE
Update LibRaw to 0.22.2

### DIFF
--- a/third-party/LibRaw/libraw/libraw_alloc.h
+++ b/third-party/LibRaw/libraw/libraw_alloc.h
@@ -34,12 +34,14 @@ public:
   {
     size_t alloc_sz = LIBRAW_MSIZE * sizeof(void *);
     mems = (void **)::malloc(alloc_sz);
-    memset(mems, 0, alloc_sz);
+	if(mems)
+		memset(mems, 0, alloc_sz);
   }
   ~libraw_memmgr()
   {
     cleanup();
-    ::free(mems);
+	if(mems)
+		::free(mems);
   }
   void *malloc(size_t sz)
   {
@@ -71,6 +73,7 @@ public:
   }
   void cleanup(void)
   {
+	if (!mems) return;
     for (int i = 0; i < LIBRAW_MSIZE; i++)
       if (mems[i])
       {
@@ -84,6 +87,7 @@ private:
   unsigned extra_bytes;
   void mem_ptr(void *ptr)
   {
+	  if (!mems) return;
 #if defined(LIBRAW_USE_OPENMP)
       bool ok = false; /* do not return from critical section */
 #endif
@@ -126,6 +130,7 @@ private:
   }
   void forget_ptr(void *ptr)
   {
+	if (!mems) return;
 #if defined(LIBRAW_USE_OPENMP)
 #pragma omp critical
     {

--- a/third-party/LibRaw/libraw/libraw_version.h
+++ b/third-party/LibRaw/libraw/libraw_version.h
@@ -22,7 +22,7 @@ it under the terms of the one of two licenses as you choose:
 
 #define LIBRAW_MAJOR_VERSION 0
 #define LIBRAW_MINOR_VERSION 22
-#define LIBRAW_PATCH_VERSION 1
+#define LIBRAW_PATCH_VERSION 2
 #define LIBRAW_VERSION_TAIL Release
 
 #define LIBRAW_SHLIB_CURRENT 25

--- a/third-party/LibRaw/src/decoders/crx.cpp
+++ b/third-party/LibRaw/src/decoders/crx.cpp
@@ -2265,7 +2265,7 @@ int crxReadImageHeaders(crx_data_header_t *hdr, CrxImage *img, uint8_t *mdatPtr,
                        img->memmgr.
 #endif
                    calloc(sizeof(CrxTile) * nTiles + sizeof(CrxPlaneComp) * nTiles * img->nPlanes +
-                              sizeof(CrxSubband) * nTiles * img->nPlanes * img->subbandCount,
+                              sizeof(CrxSubband) * size_t(nTiles) * size_t(img->nPlanes) * size_t(img->subbandCount),
                           1);
     if (!img->tiles)
       return -1;
@@ -2495,7 +2495,7 @@ int crxReadImageHeaders(crx_data_header_t *hdr, CrxImage *img, uint8_t *mdatPtr,
 }
 
 int crxSetupImageData(crx_data_header_t *hdr, CrxImage *img, int16_t *outBuf, int64_t mdatOffset, int64_t mdatSize,
-                      uint8_t *mdatHdrPtr, int32_t mdatHdrSize)
+                      uint8_t *mdatHdrPtr, int32_t mdatHdrSize, unsigned max_raw_mb)
 {
   int IncrBitTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0};
 
@@ -2533,11 +2533,14 @@ int crxSetupImageData(crx_data_header_t *hdr, CrxImage *img, int16_t *outBuf, in
   // left as is.
   if (img->encType == 3 && img->nPlanes == 4 && img->nBits > 8)
   {
+	  INT64 alloc_sz = INT64(img->planeHeight) * INT64(img->planeWidth) * INT64(img->nPlanes) * INT64((img->samplePrecision + 7) >> 3);
+	  if (alloc_sz > INT64(max_raw_mb) * 1024LL * 1024LL)
+		  throw LIBRAW_EXCEPTION_TOOBIG;
       img->planeBuf = (int16_t *)
 #ifdef LIBRAW_CR3_MEMPOOL
                           img->memmgr.
 #endif
-                      malloc(img->planeHeight * img->planeWidth * img->nPlanes * ((img->samplePrecision + 7) >> 3));
+                      malloc(alloc_sz);
     if (!img->planeBuf)
       return -1;
   }
@@ -2700,7 +2703,7 @@ void LibRaw::crxLoadRaw()
   // parse and setup the image data
   if (crxSetupImageData(&hdr, &img, (int16_t *)imgdata.rawdata.raw_image,
 	  libraw_internal_data.unpacker_data.data_offset, libraw_internal_data.unpacker_data.data_size,
-	  hdrBuf.data(), hdr.mdatHdrSize))
+	  hdrBuf.data(), hdr.mdatHdrSize, imgdata.rawparams.max_raw_memory_mb))
     throw LIBRAW_EXCEPTION_IO_CORRUPT;
 
   crxLoadDecodeLoop(&img, hdr.nPlanes);

--- a/third-party/LibRaw/src/decoders/decoders_libraw.cpp
+++ b/third-party/LibRaw/src/decoders/decoders_libraw.cpp
@@ -749,13 +749,16 @@ struct iiq_bitstream_t
 	uint64_t curr;
 	uint32_t *input;
 	uint8_t used;
-	iiq_bitstream_t(uint32_t *img_input): curr(0),input(img_input),used(0){}
+	size_t pos, maxpos;
+	iiq_bitstream_t(uint32_t *img_input, size_t inpsz): curr(0),input(img_input),used(0),pos(0),maxpos(inpsz){}
 
 	void fill()
     {
       if (used <= 32)
       {
         uint64_t bitpump_next = *input++;
+		pos++;
+		if (pos > maxpos) throw LIBRAW_EXCEPTION_IO_EOF;
         curr = (curr << 32) | bitpump_next;
         used += 32;
       }
@@ -784,13 +787,13 @@ struct iiq_bitstream_t
 
 };
 
-void decode_S_type(int32_t out_width, uint32_t *img_input, ushort *outbuf /*, int bit_depth*/)
+void decode_S_type(int32_t out_width, uint32_t *img_input, ushort *outbuf, size_t datalen /*, int bit_depth*/)
 {
 #if 0
 	if (((bit_depth - 12) & 0xFFFFFFFD) != 0)
 		return 0;
 #endif
-	iiq_bitstream_t stream(img_input);
+	iiq_bitstream_t stream(img_input,datalen);
 
 	const int pix_corr_shift = 2; // 16 - bit_depth;
 	unsigned int bit_check[2] = { 0, 0 };
@@ -907,7 +910,7 @@ void LibRaw::phase_one_load_raw_s()
 	stripes[imgdata.sizes.raw_height].offset = libraw_internal_data.unpacker_data.data_offset + INT64(libraw_internal_data.unpacker_data.data_size);
 	std::sort(stripes.begin(), stripes.end());
 	INT64 maxsz = imgdata.sizes.raw_width * 3 + 2; // theor max: 17 bytes per 8 pix + row header
-	std::vector<uint8_t> datavec(maxsz);
+	std::vector<uint8_t> datavec(maxsz+4);
 
 	for (unsigned row = 0; row < imgdata.sizes.raw_height; row++)
 	{
@@ -921,7 +924,7 @@ void LibRaw::phase_one_load_raw_s()
 		if(libraw_internal_data.internal_data.input->read(datavec.data(), 1, readsz) != readsz)
 			derror(); // TODO: check read state
 
-		decode_S_type(imgdata.sizes.raw_width, (uint32_t *)datavec.data(), datap /*, 14 */);
+		decode_S_type(imgdata.sizes.raw_width, (uint32_t *)datavec.data(), datap, readsz /*, 14 */);
 	}
 }
 

--- a/third-party/LibRaw/src/decoders/decoders_libraw_dcrdefs.cpp
+++ b/third-party/LibRaw/src/decoders/decoders_libraw_dcrdefs.cpp
@@ -299,8 +299,8 @@ void LibRaw::rpi_load_raw8()
 	for (row = 0; row < raw_height; row++) {
 		if (fread(data + dwide, 1, dwide, ifp) < dwide) derror();
 		FORC(dwide) data[c] = data[dwide + (c ^ rev)];
-		for (dp = data, col = 0; col < raw_width; dp++, col++)
-			RAW(row, col + c) = dp[c];
+		for (dp = data, col = 0; col < raw_width && col < dwide; dp++, col++)
+			RAW(row, col) = *dp;
 	}
 	free(data);
 	maximum = 0xff;
@@ -396,8 +396,8 @@ void LibRaw::rpi_load_raw16()
 	for (row = 0; row < raw_height; row++) {
 		if (fread(data + dwide, 1, dwide, ifp) < dwide) derror();
 		FORC(dwide) data[c] = data[dwide + (c ^ rev)];
-		for (dp = data, col = 0; col < raw_width; dp += 2, col++)
-			RAW(row, col + c) = (dp[1] << 8) | dp[0];
+		for (dp = data, col = 0; col < raw_width && col < dwide/2; dp += 2, col++)
+			RAW(row, col) = (dp[1] << 8) | dp[0];
 	}
 	free(data);
 	maximum = 0xffff;

--- a/third-party/LibRaw/src/decoders/fp_dng.cpp
+++ b/third-party/LibRaw/src/decoders/fp_dng.cpp
@@ -345,6 +345,10 @@ void LibRaw::deflate_dng_load_raw()
   if (imgdata.idata.filters && ifd->samples > 1)
     throw LIBRAW_EXCEPTION_DECODE_RAW;
 
+  int _bytesps = ifd->bps >> 3;
+  if (_bytesps < 2 || _bytesps > 4)
+    throw LIBRAW_EXCEPTION_DECODE_RAW; // Only 16, 24 and 32 bits are supported
+
   tile_stripe_data_t tiles;
   tiles.init(ifd, imgdata.sizes, libraw_internal_data.unpacker_data, libraw_internal_data.unpacker_data.order,
       libraw_internal_data.internal_data.input);
@@ -408,6 +412,9 @@ void LibRaw::deflate_dng_load_raw()
     {
       for (size_t x = 0; x < imgdata.sizes.raw_width; x += tiles.tileWidth, ++t)
       {
+		if(t >= tiles.tOffsets.size()) // should not happen but check anyway
+          throw LIBRAW_EXCEPTION_IO_CORRUPT; 
+
         libraw_internal_data.internal_data.input->seek(tiles.tOffsets[t], SEEK_SET);
         int bytesread = libraw_internal_data.internal_data.input->read(cBuffer.data(), 1, tiles.tBytes[t]);
 		if (bytesread < tiles.tBytes[t])
@@ -515,9 +522,18 @@ void LibRaw::convertFloatToInt(float dmin /* =4096.f */,
   else
     return;
 
-  ushort *raw_alloc = (ushort *)malloc(
-      imgdata.sizes.raw_height * imgdata.sizes.raw_width *
-      libraw_internal_data.unpacker_data.tiff_samples * sizeof(ushort));
+  INT64 pixcnt = INT64(imgdata.sizes.raw_height) * INT64(imgdata.sizes.raw_width)
+	  * INT64(libraw_internal_data.unpacker_data.tiff_samples);
+
+  if (pixcnt * sizeof(ushort) > INT64(imgdata.rawparams.max_raw_memory_mb) * 1024LL * 1024LL)
+    throw LIBRAW_EXCEPTION_TOOBIG;
+
+  ushort *raw_alloc =
+#ifdef LIBRAW_CALLOC_RAWSTORE
+		(ushort *)calloc(pixcnt, sizeof(ushort));
+#else
+		(ushort *)malloc(pixcnt * sizeof(ushort));
+#endif
   float tmax = float(MAX(imgdata.color.maximum, 1));
   float datamax = imgdata.color.fmaximum;
 
@@ -541,9 +557,7 @@ void LibRaw::convertFloatToInt(float dmin /* =4096.f */,
   else
     imgdata.rawdata.color.fnorm = imgdata.color.fnorm = 0.f;
 
-  for (size_t i = 0; i < imgdata.sizes.raw_height * imgdata.sizes.raw_width *
-                             libraw_internal_data.unpacker_data.tiff_samples;
-       ++i)
+  for (size_t i = 0; i < pixcnt; ++i)
   {
     float val = MAX(data[i], 0.f);
     raw_alloc[i] = (ushort)(val * multip);
@@ -660,7 +674,9 @@ void LibRaw::uncompressed_fp_dng_load_raw()
     {
         for (unsigned x = 0; x < imgdata.sizes.raw_width  && t < (unsigned)tiles.tileCnt; x += tiles.tileWidth, ++t)
         {
-            libraw_internal_data.internal_data.input->seek(tiles.tOffsets[t], SEEK_SET);
+			if (t >= tiles.tOffsets.size()) // should not happen but check anyway
+				throw LIBRAW_EXCEPTION_IO_CORRUPT;
+			libraw_internal_data.internal_data.input->seek(tiles.tOffsets[t], SEEK_SET);
             size_t rowsInTile = y + tiles.tileHeight > imgdata.sizes.raw_height ? imgdata.sizes.raw_height - y : tiles.tileHeight;
             size_t colsInTile = x + tiles.tileWidth > imgdata.sizes.raw_width ? imgdata.sizes.raw_width - x : tiles.tileWidth;
 

--- a/third-party/LibRaw/src/decoders/load_mfbacks.cpp
+++ b/third-party/LibRaw/src/decoders/load_mfbacks.cpp
@@ -526,7 +526,7 @@ int LibRaw::phase_one_correct()
 		  cip = (int)cfrac;
           cfrac -= cip;
           num = RAW(row, col) * 0.5f;
-          for (i = cip; i < cip + 2; i++)
+          for (i = cip; i < cip + 2 && i < head[3]; i++)
           {
             for (k = j = 0; j < head[1]; j++)
               if (num < xval[0][k = head[1] * i + j])

--- a/third-party/LibRaw/src/decoders/olympus14.cpp
+++ b/third-party/LibRaw/src/decoders/olympus14.cpp
@@ -261,6 +261,9 @@ void LibRaw::olympus_load_raw()
 		  if (wbits > tag0x651) 
             wbits = tag0x651;
 
+          if (wbits >= 16)
+            throw LIBRAW_EXCEPTION_IO_CORRUPT;
+
           int32_t gcode = oly_code(&pump, wbits, tag0x640, tag0x643, tag0x652, &glc, &t640bits, &t643bits);
           if (tag0x643) 
           {

--- a/third-party/LibRaw/src/decoders/unpack_thumb.cpp
+++ b/third-party/LibRaw/src/decoders/unpack_thumb.cpp
@@ -160,8 +160,6 @@ int LibRaw::unpack_thumb(void)
 #else
         T.thumb = (char *)malloc(T.tlength);
 #endif
-		if(!T.thumb)
-          return LIBRAW_NO_THUMBNAIL;
         ID.input->read(T.thumb, 1, T.tlength);
 		unsigned char *tthumb = (unsigned char *)T.thumb;
 		if (Tformat == LIBRAW_INTERNAL_THUMBNAIL_JPEGXL)
@@ -230,15 +228,7 @@ int LibRaw::unpack_thumb(void)
         if (T.thumb)
           free(T.thumb);
         T.thumb = (char *)calloc(colors, tlength);
-		if(!T.thumb)
-			return LIBRAW_NO_THUMBNAIL;
         unsigned char *tbuf = (unsigned char *)calloc(colors, tlength);
-		if (!tbuf)
-		{
-			free(T.thumb);
-			T.thumb = 0;
-            return LIBRAW_NO_THUMBNAIL;
-		}
         // Avoid OOB of tbuf, should use tlength
         ID.input->read(tbuf, colors, tlength);
         if (libraw_internal_data.unpacker_data.thumb_misc >> 8 &&
@@ -279,15 +269,7 @@ int LibRaw::unpack_thumb(void)
           free(T.thumb);
         T.tcolors = 3;
         T.thumb = (char *)calloc(T.tcolors, tlength);
-        if (!T.thumb)
-          return LIBRAW_NO_THUMBNAIL;
         unsigned short *tbuf = (unsigned short *)calloc(2, tlength);
-        if (!tbuf)
-        {
-          free(T.thumb);
-          T.thumb = 0;
-          return LIBRAW_NO_THUMBNAIL;
-        }
 		try {
   		  read_shorts(tbuf, tlength);
           for (i = 0; i < tlength; i++)
@@ -330,9 +312,9 @@ int LibRaw::unpack_thumb(void)
               total_size += tiff_ifd[pifd].strip_byte_counts[i];
             if (total_size != (unsigned)t_length) // recalculate colors
             {
-              if (total_size == T.twidth * T.tlength * 3)
+              if (total_size == T.twidth * T.theight * 3)
                 T.tcolors = 3;
-              else if (total_size == T.twidth * T.tlength)
+              else if (total_size == T.twidth * T.theight)
                 T.tcolors = 1;
             }
             T.tlength = unsigned(total_size);
@@ -344,9 +326,6 @@ int LibRaw::unpack_thumb(void)
 #else
             T.thumb = (char *)malloc(T.tlength);
 #endif
-            if (!T.thumb)
-              return LIBRAW_NO_THUMBNAIL;
-
             char *dest = T.thumb;
             INT64 pos = ID.input->tell();
             INT64 remain = T.tlength;
@@ -374,18 +353,17 @@ int LibRaw::unpack_thumb(void)
 
         if (!T.tlength)
           T.tlength = t_length;
-        if (T.thumb)
-          free(T.thumb);
 
-        THUMB_SIZE_CHECKTNZ(T.tlength);
+		THUMB_SIZE_CHECKTNZ(T.tlength);
+
+		if (T.thumb)
+          free(T.thumb);
 
 #ifdef LIBRAW_CALLOC_RAWSTORE
         T.thumb = (char *)calloc(T.tlength,1);
 #else
         T.thumb = (char *)malloc(T.tlength);
 #endif
-        if (!T.thumb)
-          return LIBRAW_NO_THUMBNAIL;
         if (!T.tcolors)
           T.tcolors = t_colors;
 
@@ -401,15 +379,16 @@ int LibRaw::unpack_thumb(void)
 			return LIBRAW_NO_THUMBNAIL; // 16-bit thumb, but parsed for
                                              // more bits
         int o_bps = (imgdata.rawparams.options & LIBRAW_RAWOPTIONS_USE_PPM16_THUMBS) ? 2 : 1;
-        int o_length = T.twidth * T.theight * t_colors * o_bps;
+
+		THUMB_SIZE_CHECKWH(T.twidth, (INT64(T.theight)*INT64(o_bps)));
+
+		int o_length = T.twidth * T.theight * t_colors * o_bps;
         int i_length = T.twidth * T.theight * t_colors * 2;
 
 		THUMB_SIZE_CHECKTNZ(o_length);
         THUMB_SIZE_CHECKTNZ(i_length);
 
         ushort *t_thumb = (ushort *)calloc(i_length, 1);
-		if (!t_thumb)
-			return LIBRAW_NO_THUMBNAIL;;
         ID.input->read(t_thumb, 1, i_length);
         if ((libraw_internal_data.unpacker_data.order == 0x4949) ==
             (ntohs(0x1234) == 0x1234))
@@ -430,11 +409,6 @@ int LibRaw::unpack_thumb(void)
 #else
           T.thumb = (char *)malloc(o_length);
 #endif
-		  if (!T.thumb)
-		  {
-			  free(t_thumb);
-			  return LIBRAW_NO_THUMBNAIL;
-		  }
           for (int i = 0; i < o_length; i++)
             T.thumb[i] = t_thumb[i] >> 8;
           free(t_thumb);

--- a/third-party/LibRaw/src/demosaic/misc_demosaic.cpp
+++ b/third-party/LibRaw/src/demosaic/misc_demosaic.cpp
@@ -214,6 +214,8 @@ void LibRaw::vng_interpolate()
   int row, col, x, y, x1, x2, y1, y2, t, weight, grads, color, diag;
   int g, diff, thold, num, c;
 
+  if (width < 8 || height < 8) return;  // skip interploation on too small images
+
   lin_interpolate();
 
   if (filters == 1)

--- a/third-party/LibRaw/src/demosaic/xtrans_demosaic.cpp
+++ b/third-party/LibRaw/src/demosaic/xtrans_demosaic.cpp
@@ -82,8 +82,8 @@ void LibRaw::xtrans_interpolate(int passes)
                 int h = orth[d + 2] * patt[g][c * 2] + orth[d + 3] * patt[g][c * 2 + 1];
                 minv = MIN(v, minv);
                 maxv = MAX(v, maxv);
-                minh = MIN(v, minh);
-                maxh = MAX(v, maxh);
+                minh = MIN(h, minh);
+                maxh = MAX(h, maxh);
                 allhex[row][col][0][c ^ (g * 2 & d)] = h + v * width;
                 allhex[row][col][1][c ^ (g * 2 & d)] = h + v * LIBRAW_AHD_TILE;
             }

--- a/third-party/LibRaw/src/integration/dngsdk_glue.cpp
+++ b/third-party/LibRaw/src/integration/dngsdk_glue.cpp
@@ -371,11 +371,20 @@ int LibRaw::try_dngsdk()
     dng_pixel_buffer buffer;
     stage2->GetPixelBuffer(buffer);
 
-    int pixels = stage2->Bounds().H() * stage2->Bounds().W() * pplanes;
+    INT64 pixels = INT64(stage2->Bounds().H()) * INT64(stage2->Bounds().W()) * INT64(pplanes);
+
+	INT64 allocsz = pixels * TagTypeSize(ptype);
+    if (allocsz > INT64(imgdata.rawparams.max_raw_memory_mb) * INT64(1024 * 1024))
+      throw LIBRAW_EXCEPTION_TOOBIG;
 
     if (ptype == ttShort && !(stageBits & 1) &&  !is_curve_linear())
     {
-      imgdata.rawdata.raw_alloc = malloc(pixels * TagTypeSize(ptype));
+      imgdata.rawdata.raw_alloc 
+#ifdef LIBRAW_CALLOC_RAWSTORE
+          = calloc(pixels, TagTypeSize(ptype));
+#else
+		  = malloc(pixels * TagTypeSize(ptype));
+#endif
       ushort *src = (ushort *)buffer.fData;
       ushort *dst = (ushort *)imgdata.rawdata.raw_alloc;
       for (int i = 0; i < pixels; i++)
@@ -385,7 +394,12 @@ int LibRaw::try_dngsdk()
     }
     else if (ptype == ttByte)
     {
-      imgdata.rawdata.raw_alloc = malloc(pixels * TagTypeSize(ttShort));
+      imgdata.rawdata.raw_alloc 
+#ifdef LIBRAW_CALLOC_RAWSTORE
+          = calloc(pixels, TagTypeSize(ttShort));
+#else
+		  = malloc(pixels * TagTypeSize(ttShort));
+#endif
       unsigned char *src = (unsigned char *)buffer.fData;
       ushort *dst = (ushort *)imgdata.rawdata.raw_alloc;
       if (is_curve_linear())
@@ -408,7 +422,12 @@ int LibRaw::try_dngsdk()
       }
       else
       {
-        imgdata.rawdata.raw_alloc = malloc(pixels * TagTypeSize(ptype));
+        imgdata.rawdata.raw_alloc 
+#ifdef LIBRAW_CALLOC_RAWSTORE
+            = calloc(pixels, TagTypeSize(ptype));
+#else
+            = malloc(pixels * TagTypeSize(ptype));
+#endif
         memmove(imgdata.rawdata.raw_alloc, buffer.fData,
                 pixels * TagTypeSize(ptype));
       }

--- a/third-party/LibRaw/src/libraw_c_api.cpp
+++ b/third-party/LibRaw/src/libraw_c_api.cpp
@@ -444,21 +444,21 @@ extern "C"
   DllDef float libraw_get_cam_mul(libraw_data_t *lr, int index)
   {
     if (!lr)
-      return EINVAL;
+      return -999.f;
     return lr->color.cam_mul[LIM(index, 0, 3)];
   }
 
   DllDef float libraw_get_pre_mul(libraw_data_t *lr, int index)
   {
     if (!lr)
-      return EINVAL;
+      return -999.f;
     return lr->color.pre_mul[LIM(index, 0, 3)];
   }
 
   DllDef float libraw_get_rgb_cam(libraw_data_t *lr, int index1, int index2)
   {
     if (!lr)
-      return EINVAL;
+      return -999.f;
     return lr->color.rgb_cam[LIM(index1, 0, 2)][LIM(index2, 0, 3)];
   }
 

--- a/third-party/LibRaw/src/libraw_datastream.cpp
+++ b/third-party/LibRaw/src/libraw_datastream.cpp
@@ -417,12 +417,15 @@ char *LibRaw_buffer_datastream::gets(char *s, int sz)
 int LibRaw_buffer_datastream::scanf_one(const char *fmt, void *val)
 {
   int scanf_res;
-  if (streampos > streamsize)
+  if (streampos > streamsize-24) // we assume at least 24 bytes in buffer, same assumption as in bigfile buffered datastream
     return 0;
+  char scanf_buffer[25];
+  memcpy(scanf_buffer, buf + streampos, 24);
+  scanf_buffer[24] = 0;
 #ifndef WIN32SECURECALLS
-  scanf_res = sscanf((char *)(buf + streampos), fmt, val);
+  scanf_res = sscanf(scanf_buffer, fmt, val);
 #else
-  scanf_res = sscanf_s((char *)(buf + streampos), fmt, val);
+  scanf_res = sscanf_s(scanf_buffer, fmt, val);
 #endif
   if (scanf_res > 0)
   {

--- a/third-party/LibRaw/src/metadata/cr3_parser.cpp
+++ b/third-party/LibRaw/src/metadata/cr3_parser.cpp
@@ -222,9 +222,9 @@ void LibRaw::selectCRXTrack()
     int tiff_idx = -1;
     INT64 tpixels = 0;
     for (unsigned i = 0; i < tiff_nifds && i < LIBRAW_IFD_MAXCOUNT; i++)
-      if (INT64(tiff_ifd[i].t_height) * INT64(tiff_ifd[i].t_height) > tpixels)
+      if (INT64(tiff_ifd[i].t_width) * INT64(tiff_ifd[i].t_height) > tpixels)
       {
-        tpixels = INT64(tiff_ifd[i].t_height) * INT64(tiff_ifd[i].t_height);
+        tpixels = INT64(tiff_ifd[i].t_width) * INT64(tiff_ifd[i].t_height);
         tiff_idx = i;
       }
     if (tiff_idx >= 0)

--- a/third-party/LibRaw/src/metadata/exif_gps.cpp
+++ b/third-party/LibRaw/src/metadata/exif_gps.cpp
@@ -236,6 +236,7 @@ void LibRaw::parse_exif(INT64 base)
         ushort l;
         float num;
 
+		memset(mn_text, 0, sizeof(mn_text));
         fgets(mn_text, MIN(len, 511), ifp);
         mn_text[511] = 0;
 

--- a/third-party/LibRaw/src/metadata/fuji.cpp
+++ b/third-party/LibRaw/src/metadata/fuji.cpp
@@ -1324,6 +1324,7 @@ void LibRaw::parse_fuji(INT64 offset)
         uchar RAFDataHeader[16];
         libraw_internal_data.unpacker_data.posRAFData = save;
         libraw_internal_data.unpacker_data.lenRAFData = (len >> 1);
+		memset(RAFDataHeader, 0, sizeof(RAFDataHeader));
         fread(RAFDataHeader, sizeof RAFDataHeader, 1, ifp);
         offsetWH_inRAFData = guess_RAFDataGeneration(RAFDataHeader);
         fseek(ifp, offsetWH_inRAFData-int(sizeof RAFDataHeader), SEEK_CUR);

--- a/third-party/LibRaw/src/metadata/identify.cpp
+++ b/third-party/LibRaw/src/metadata/identify.cpp
@@ -628,7 +628,11 @@ void LibRaw::identify()
   else if (!memcmp(head + 4, "ftypqt   ", 9))
   {
     fseek(ifp, 0, SEEK_SET);
+	// Use existing variable that definitely not used in parse_qt/parse_jpeg to avoid ABI change
+	short cr3save = libraw_internal_data.unpacker_data.CR3_Version;
+	libraw_internal_data.unpacker_data.CR3_Version = 32;
     parse_qt(fsize);
+	libraw_internal_data.unpacker_data.CR3_Version = cr3save;
     is_raw = 0;
   }
   else if (!memcmp(head, "\0\001\0\001\0@", 6))
@@ -1223,6 +1227,10 @@ dng_skip:
 	// Prevent incorrect-sized fuji-rotated files
 	if (INT64(width)*INT64(height) > INT64(raw_width) * INT64(raw_height) * 8LL)
 		is_raw = 0;
+
+	// All 'fuji-rotated' images are 6Mpix or less, so 8k x 8k limit is OK
+	if(width > 8192 || height > 8192 || raw_width > 8192 || raw_height > 8192)
+      is_raw = 0;
   }
   else
   {

--- a/third-party/LibRaw/src/metadata/identify_tools.cpp
+++ b/third-party/LibRaw/src/metadata/identify_tools.cpp
@@ -45,7 +45,7 @@ float LibRaw::find_green(int bps, int bite, int off0, int off1)
 {
   UINT64 bitbuf = 0;
   int vbits, col, i, c;
-  ushort img[2][2064];
+  ushort img[2][2065];
   float sum[] = {0, 0};
   if (width > 2064)
     return 0.f; // too wide
@@ -79,12 +79,19 @@ void LibRaw::trimSpaces(char *s)
 {
   char *p = s;
   int l = int(strlen(p));
-  if (!l)
+  if (l<1)
     return;
-  while (isspace(p[l - 1]))
+  while (l > 0 && isspace(p[l - 1]))
     p[--l] = 0; /* trim trailing spaces */
-  while (*p && isspace(*p))
+  if (l < 1)
+	  return; // only spaces in the input string, all wiped out;
+  while (*p && isspace(*p) && l > 0)
     ++p, --l;   /* trim leading spaces */
+  if (l < 1)  // should not happen, but safety belt
+  {
+	  *s = 0;
+	  return;
+  }
   memmove(s, p, l + 1);
 }
 
@@ -122,6 +129,8 @@ void LibRaw::remove_caseSubstr(char *string, char *subStr) // replace a substrin
 void LibRaw::removeExcessiveSpaces(char *string) // replace repeating spaces with one space
 {
 	int orig_len = int(strlen(string));
+	if (orig_len < 1)
+		return;
 	int i = 0;   // counter for resulting string
 	int j = -1;
 	bool prev_char_is_space = false;
@@ -137,6 +146,8 @@ void LibRaw::removeExcessiveSpaces(char *string) // replace repeating spaces wit
 			}
 		}
 	}
-	if (string[i-1] == ' ')
-    string[i-1] = 0;
+    if (i > 0 && string[i - 1] == ' ')
+		string[i-1] = 0;
+	if(i < orig_len)
+		string[i] = 0; 
 }

--- a/third-party/LibRaw/src/metadata/mediumformat.cpp
+++ b/third-party/LibRaw/src/metadata/mediumformat.cpp
@@ -123,8 +123,10 @@ void LibRaw::parse_phase_one(INT64 base)
       break;
     case 0x0203:
       stmread(imPhaseOne.Software, len, ifp);
+	  break;
     case 0x0204:
       stmread(imPhaseOne.SystemType, len, ifp);
+	  break;
     case 0x0210:
       ph1.tag_210 = int_to_float(data);
       imCommon.SensorTemperature = ph1.tag_210;
@@ -199,6 +201,7 @@ void LibRaw::parse_phase_one(INT64 base)
         }
         *cp = 0;
       }
+	  break;
     case 0x0401:
       if (tagtypeIs(LIBRAW_EXIFTAG_TYPE_LONG))
         ilm.CurAp = libraw_powf64l(2.0f, (int_to_float(data) / 2.0f));
@@ -401,6 +404,10 @@ void LibRaw::parse_mos(INT64 offset)
   };
   float romm_cam[3][3];
 
+  libraw_internal_data.unpacker_data.CR3_Version--;
+  if (libraw_internal_data.unpacker_data.CR3_Version < 1)
+	  throw LIBRAW_EXCEPTION_IO_CORRUPT;
+
   fseek(ifp, offset, SEEK_SET);
   while (!feof(ifp))
   {
@@ -538,4 +545,6 @@ void LibRaw::parse_mos(INT64 offset)
   if (planes)
     filters = (planes == 1) * 0x01010101U *
               (uchar) "\x94\x61\x16\x49"[(flip / 90 + frot) & 3];
+  libraw_internal_data.unpacker_data.CR3_Version++;
+
 }

--- a/third-party/LibRaw/src/metadata/misc_parsers.cpp
+++ b/third-party/LibRaw/src/metadata/misc_parsers.cpp
@@ -166,6 +166,8 @@ void LibRaw::parse_qt(INT64 end)
   unsigned size;
   INT64 save;
   char tag[4];
+  if (libraw_internal_data.unpacker_data.CR3_Version-- < 1)
+	  throw LIBRAW_EXCEPTION_IO_CORRUPT;
 
   order = 0x4d4d;
   while (ftell(ifp) + 7 < end)

--- a/third-party/LibRaw/src/metadata/olympus.cpp
+++ b/third-party/LibRaw/src/metadata/olympus.cpp
@@ -644,80 +644,90 @@ void LibRaw::parseOlympusMakernotes (INT64 base, unsigned tag, unsigned type, un
 
   } else {
 		switch (tag) {
-			case 0x0200:
-			  FORC3 if ((imOly.SpecialMode[c] = get4()) >= 0xff) imOly.SpecialMode[c] = 0xffffffff;
-			  break;
-			case 0x0207:
-				getOlympus_CameraType2();
-				break;
-			case 0x0404:
-			case 0x101a:
-				if (!imgdata.shootinginfo.BodySerial[0] && (dng_writer == nonDNG))
-					stmread(imgdata.shootinginfo.BodySerial, len, ifp);
-				break;
-			case 0x1002:
-				ilm.CurAp = float(libraw_powf64l(2.0f, getrealf(type) / 2.f));
-				break;
-			case 0x1007:
-				imCommon.SensorTemperature = (float)get2();
-				break;
-			case 0x1008:
-				imCommon.LensTemperature = (float)get2();
-				break;
-			case 0x100b:
-				if (imOly.FocusMode[0] == 0xffff) {
-					imgdata.shootinginfo.FocusMode = imOly.FocusMode[0] = get2();
-					if (imgdata.shootinginfo.FocusMode == 1)
-						imgdata.shootinginfo.FocusMode = imOly.FocusMode[0] = 10;
-				}
-				break;
+        case 0x0200:
+          FORC3 if ((imOly.SpecialMode[c] = get4()) >= 0xff) imOly.SpecialMode[c] = 0xffffffff;
+          break;
+        case 0x0207:
+          getOlympus_CameraType2();
+          break;
+        case 0x0404:
+        case 0x101a:
+          if (!imgdata.shootinginfo.BodySerial[0] && (dng_writer == nonDNG))
+            stmread(imgdata.shootinginfo.BodySerial, len, ifp);
+          break;
+        case 0x1002:
+          ilm.CurAp = float(libraw_powf64l(2.0f, getrealf(type) / 2.f));
+          break;
+        case 0x1007:
+          imCommon.SensorTemperature = (float)get2();
+          break;
+        case 0x1008:
+          imCommon.LensTemperature = (float)get2();
+          break;
+        case 0x100b:
+          if (imOly.FocusMode[0] == 0xffff)
+          {
+            imgdata.shootinginfo.FocusMode = imOly.FocusMode[0] = get2();
+            if (imgdata.shootinginfo.FocusMode == 1)
+              imgdata.shootinginfo.FocusMode = imOly.FocusMode[0] = 10;
+          }
+          break;
       case 0x100d:
         if (imOly.ZoomStepCount == 0xffff) imOly.ZoomStepCount = get2();
         break;
       case 0x100e:
-        if (imOly.FocusStepCount == 0xffff) imOly.FocusStepCount = get2();
+        if (imOly.FocusStepCount == 0xffff)
+          imOly.FocusStepCount = get2();
         break;
-			case 0x1011:
-				if (strcmp(software, "v757-71") && (dng_writer == nonDNG)) {
-					for (int i = 0; i < 3; i++) {
-						if (!imOly.ColorSpace) {
-							FORC3 cmatrix[i][c] = float((short)get2()) / 256.f;
-						} else {
-							FORC3 imgdata.color.ccm[i][c] = float((short)get2()) / 256.f;
-						}
-					}
-				}
-				break;
-			case 0x1012:
-			  if (dng_writer == nonDNG)
-				  FORC4 cblack[RGGB_2_RGBG(c)] = get2();
-				break;
-			case 0x1017:
-				if (dng_writer == nonDNG)
-				  cam_mul[0] = float(get2()) / 256.f;
-				break;
-			case 0x1018:
-				if (dng_writer == nonDNG)
-				  cam_mul[2] = float(get2()) / 256.f;
-				break;
-			case 0x102c:
-				if (dng_writer == nonDNG)
-				  imOly.ValidBits = get2();
-				break;
-			case 0x1038:
-				imOly.AFResult = get2();
-				break;
+      case 0x1011:
+        if (strcmp(software, "v757-71") && (dng_writer == nonDNG))
+        {
+          for (int i = 0; i < 3; i++)
+          {
+            if (!imOly.ColorSpace)
+            {
+              FORC3 cmatrix[i][c] = float((short)get2()) / 256.f;
+            }
+            else
+            {
+              FORC3 imgdata.color.ccm[i][c] = float((short)get2()) / 256.f;
+            }
+          }
+        }
+        break;
+      case 0x1012:
+        if (dng_writer == nonDNG)
+          FORC4 cblack[RGGB_2_RGBG(c)] = get2();
+        break;
+      case 0x1017:
+        if (dng_writer == nonDNG)
+          cam_mul[0] = float(get2()) / 256.f;
+        break;
+      case 0x1018:
+        if (dng_writer == nonDNG)
+          cam_mul[2] = float(get2()) / 256.f;
+        break;
+      case 0x102c:
+        if (dng_writer == nonDNG)
+          imOly.ValidBits = get2();
+        break;
+      case 0x1038:
+        imOly.AFResult = get2();
+        break;
       case 0x103b:
         if (imOly.FocusStepInfinity == 0xffff) imOly.FocusStepInfinity = get2();
         break;
       case 0x103c:
-        if (imOly.FocusStepNear == 0xffff) imOly.FocusStepNear = get2();
+        if (imOly.FocusStepNear == 0xffff)
+          imOly.FocusStepNear = get2();
         break;
-			case 0x20300108:
-			case 0x20310109:
-				if (dng_writer == nonDNG) {
+      case 0x20300108:
+      case 0x20310109:
+        if (dng_writer == nonDNG)
+        {
           imOly.ColorSpace = get2();
-          switch (imOly.ColorSpace) {
+          switch (imOly.ColorSpace)
+          {
           case 0:
             imCommon.ColorSpace = LIBRAW_COLORSPACE_sRGB;
             break;
@@ -731,34 +741,37 @@ void LibRaw::parseOlympusMakernotes (INT64 base, unsigned tag, unsigned type, un
             imCommon.ColorSpace = LIBRAW_COLORSPACE_Unknown;
             break;
           }
-				}
-			case 0x20500209:
-				imOly.AutoFocus = get2();
-				break;
-			case 0x20500300:
-			  imOly.ZoomStepCount = get2();
-			  break;
-			case 0x20500301:
-			  imOly.FocusStepCount = get2();
-			  break;
-			case 0x20500303:
-			  imOly.FocusStepInfinity = get2();
-			  break;
-			case 0x20500304:
-			  imOly.FocusStepNear = get2();
-			  break;
-			case 0x20500305:
-			  a = get4();
-			  /*b = */ get4(); // b is not used, so removed
-			  if (a >= 0x7f000000) imOly.FocusDistance = -1.0; // infinity
-			  else imOly.FocusDistance = (double) a / 1000.0;  // convert to meters
-			  break;
-			case 0x20500308:
-				imOly.AFPoint = get2();
-				break;
-			case 0x20501500:
-				getOlympus_SensorTemperature(len);
-				break;
-		}
+        }
+        break;
+      case 0x20500209:
+        imOly.AutoFocus = get2();
+        break;
+      case 0x20500300:
+        imOly.ZoomStepCount = get2();
+        break;
+      case 0x20500301:
+        imOly.FocusStepCount = get2();
+        break;
+      case 0x20500303:
+        imOly.FocusStepInfinity = get2();
+        break;
+      case 0x20500304:
+        imOly.FocusStepNear = get2();
+        break;
+      case 0x20500305:
+        a = get4();
+        /*b = */ get4(); // b is not used, so removed
+        if (a >= 0x7f000000)
+          imOly.FocusDistance = -1.0; // infinity
+        else
+          imOly.FocusDistance = (double)a / 1000.0; // convert to meters
+        break;
+      case 0x20500308:
+        imOly.AFPoint = get2();
+        break;
+      case 0x20501500:
+        getOlympus_SensorTemperature(len);
+        break;
+      }
   }
 }

--- a/third-party/LibRaw/src/metadata/sony.cpp
+++ b/third-party/LibRaw/src/metadata/sony.cpp
@@ -2335,6 +2335,9 @@ void LibRaw::parseSonySRF(unsigned len)
       offset += srf_buf[int(offset)] << 2;
 
 	  int ioffset = int(offset);
+	  
+	  if (ioffset + 3 >= len)
+        goto restore_after_parseSonySRF;
       /* master key is stored in big endian */
       MasterKey = ((unsigned)srf_buf[ioffset] << 24) |
           ((unsigned)srf_buf[ioffset + 1] << 16) |

--- a/third-party/LibRaw/src/metadata/tiff.cpp
+++ b/third-party/LibRaw/src/metadata/tiff.cpp
@@ -41,6 +41,9 @@ int LibRaw::parse_tiff_ifd(INT64 base)
     for (i = 0; i < 4; i++)
       cc[j][i] = i == j;
 
+  memset(cm,0,sizeof(cm));
+  memset(fm,0,sizeof(fm));
+
   if (libraw_internal_data.unpacker_data.ifd0_offset == -1LL)
     libraw_internal_data.unpacker_data.ifd0_offset = base;
 
@@ -914,7 +917,14 @@ int LibRaw::parse_tiff_ifd(INT64 base)
       }
       break;
     case 0x8606: /* 34310, Leaf metadata */
-      parse_mos(ftell(ifp));
+	{
+      // libraw_internal_data.unpacker_data.CR3_Version is not used in MOS parser
+		short crs = libraw_internal_data.unpacker_data.CR3_Version;
+		libraw_internal_data.unpacker_data.CR3_Version = 64;  // typical value is 7, so 64 is enough
+        parse_mos(ftell(ifp));
+        libraw_internal_data.unpacker_data.CR3_Version = crs;
+	}
+	// fallthrough
     case 0x85ff: // 34303
       strcpy(make, "Leaf");
       break;
@@ -1523,6 +1533,7 @@ int LibRaw::parse_tiff_ifd(INT64 base)
         unsigned MakN_order, m_sorder = order;
         unsigned MakN_length;
         unsigned pos_in_original_raw;
+		memset(mbuf, 0, sizeof(mbuf));
         fread(mbuf, 1, 6, ifp);
 
         if (!strcmp(mbuf, "Adobe"))

--- a/third-party/LibRaw/src/postprocessing/mem_image.cpp
+++ b/third-party/LibRaw/src/postprocessing/mem_image.cpp
@@ -78,7 +78,7 @@ libraw_processed_image_t *LibRaw::dcraw_make_mem_thumb(int *errcode)
   {
     ushort exif[5];
     int mk_exif = 0;
-    if (strcmp(T.thumb + 6, "Exif"))
+    if (memcmp(T.thumb + 6, "Exif\0",5))
       mk_exif = 1;
 
     int dsize = T.tlength + mk_exif * (sizeof(exif) + sizeof(tiff_hdr));
@@ -231,7 +231,7 @@ int LibRaw::copy_mem_image(void *scan0, int stride, int bgr)
 
   for (row = 0; row < S.height; row++, soff += rstep)
   {
-    uchar *bufp = ((uchar *)scan0) + row * stride;
+    uchar *bufp = ((uchar *)scan0) + size_t(row) * size_t(stride);
     ppm2 = (ushort *)(ppm = bufp);
     // keep trivial decisions in the outer loop for speed
     if (bgr)
@@ -280,7 +280,7 @@ libraw_processed_image_t *LibRaw::dcraw_make_mem_image(int *errcode)
   int width, height, colors, bps;
   get_mem_image_format(&width, &height, &colors, &bps);
   int stride = width * (bps / 8) * colors;
-  unsigned ds = height * stride;
+  INT64 ds = INT64(height) * INT64(stride);
   libraw_processed_image_t *ret = (libraw_processed_image_t *)::malloc(
       sizeof(libraw_processed_image_t) + ds);
   if (!ret)

--- a/third-party/LibRaw/src/postprocessing/postprocessing_aux.cpp
+++ b/third-party/LibRaw/src/postprocessing/postprocessing_aux.cpp
@@ -40,14 +40,15 @@ void LibRaw::wavelet_denoise()
                                 0.0291f, 0.0152f, 0.0080f, 0.0044f};
 
   if (iwidth < 65 || iheight < 65) return;
+  if (int64_t(iwidth) * int64_t(iheight) >= 0x15540000LL) return; // ensure pixel count less then 358M so total allocation size is less then 4GB
 
   while (maximum << scale < 0x10000)
     scale++;
   maximum <<= --scale;
   black <<= scale;
   FORC4 cblack[c] <<= scale;
-  if ((size = iheight * iwidth) < 0x15550000)
-    fimg = (float *)malloc((size * 3 + iheight + iwidth + 128) * sizeof *fimg);
+  size = iheight * iwidth;
+  fimg = (float *)malloc((size * 3 + iheight + iwidth + 128) * sizeof *fimg);
   temp = fimg + size * 3;
   if ((nc = colors) == 3 && filters)
     nc++;
@@ -138,14 +139,15 @@ void LibRaw::wavelet_denoise()
 
   if (iwidth < 65 || iheight < 65)
     return;
+  if (int64_t(iwidth) * int64_t(iheight) >= 0x15540000LL)
+    return; // ensure pixel count less then 358M so total allocation size is less then 4GB
 
   while (maximum << scale < 0x10000)
     scale++;
   maximum <<= --scale;
   black <<= scale;
   FORC4 cblack[c] <<= scale;
-  if ((size = iheight * iwidth) < 0x15550000)
-    fimg = (float *)malloc((size * 3 + iheight + iwidth) * sizeof *fimg);
+  fimg = (float *)malloc((size * 3 + iheight + iwidth) * sizeof *fimg);
   temp = fimg + size * 3;
   if ((nc = colors) == 3 && filters)
     nc++;

--- a/third-party/LibRaw/src/preprocessing/raw2image.cpp
+++ b/third-party/LibRaw/src/preprocessing/raw2image.cpp
@@ -85,17 +85,16 @@ int LibRaw::raw2image(void)
     }
 
     // free and re-allocate image bitmap
-	int extra = P1.filters ? (P1.filters == 9 ? 6 : 2) : 0;
+	INT64 extra = P1.filters ? (P1.filters == 9 ? 6LL : 2LL) : 0LL;
+	INT64 allocate_sz = (INT64(S.iheight) + extra) * (INT64(S.iwidth) + extra);
     if (imgdata.image)
     {
-      imgdata.image = (ushort(*)[4])realloc(
-          imgdata.image, (S.iheight+extra) * (S.iwidth+extra) * sizeof(*imgdata.image));
-      memset(imgdata.image, 0, (S.iheight+extra) * (S.iwidth+extra) * sizeof(*imgdata.image));
+      imgdata.image = (ushort(*)[4])realloc(imgdata.image, allocate_sz * sizeof(*imgdata.image));
+      memset(imgdata.image, 0, allocate_sz * sizeof(*imgdata.image));
     }
     else
       imgdata.image =
-          (ushort(*)[4])calloc((S.iheight+extra) * (S.iwidth+extra), sizeof(*imgdata.image));
-
+          (ushort(*)[4])calloc(allocate_sz, sizeof(*imgdata.image));
 
     libraw_decoder_info_t decoder_info;
     get_decoder_info(&decoder_info);
@@ -407,7 +406,7 @@ int LibRaw::raw2image_ex(int do_subtract_black)
       alloc_height = (t_alloc_height + IO.shrink) >> IO.shrink;
       alloc_width = (t_alloc_width + IO.shrink) >> IO.shrink;
     }
-    int alloc_sz = alloc_width * alloc_height;
+    INT64 alloc_sz = INT64(alloc_width) * INT64(alloc_height);
 
     if (imgdata.image)
     {

--- a/third-party/LibRaw/src/utils/open.cpp
+++ b/third-party/LibRaw/src/utils/open.cpp
@@ -271,6 +271,15 @@ int LibRaw::open_bayer(const unsigned char *buffer, unsigned datalen,
   if (!buffer || buffer == (const void *)-1)
     return LIBRAW_IO_ERROR;
 
+  if (_raw_width < 22 || _raw_height < 22) // 3=> 22 as in open_file/identify
+	  return LIBRAW_FILE_UNSUPPORTED;
+
+  if (int(_left_margin) + int(_right_margin) + 21 >= _raw_width) // limit to 22 as in open_file/identify
+    return LIBRAW_FILE_UNSUPPORTED;
+
+  if(int(_top_margin) + int(_bottom_margin) + 21 >= _raw_height) // limit to 22 as in open_file/identify
+    return LIBRAW_FILE_UNSUPPORTED;
+
   LibRaw_buffer_datastream *stream;
   try
   {
@@ -303,7 +312,7 @@ int LibRaw::open_bayer(const unsigned char *buffer, unsigned datalen,
   S.width = S.raw_width - S.left_margin - _right_margin;
   S.height = S.raw_height - S.top_margin - _bottom_margin;
 
-  imgdata.idata.filters = 0x1010101 * bayer_pattern;
+  imgdata.idata.filters = 0x1010101u * bayer_pattern;
   imgdata.idata.colors =
       4 - !((imgdata.idata.filters & imgdata.idata.filters >> 1) & 0x5555);
   libraw_internal_data.unpacker_data.load_flags = otherflags;
@@ -337,6 +346,9 @@ int LibRaw::open_bayer(const unsigned char *buffer, unsigned datalen,
         libraw_internal_data.unpacker_data.load_flags =
             libraw_internal_data.unpacker_data.load_flags >> 1 & 7;
     load_raw = &LibRaw::unpacked_load_raw;
+	break;
+  default:
+	  return LIBRAW_FILE_UNSUPPORTED;
   }
   C.maximum =
       (1 << libraw_internal_data.unpacker_data.tiff_bps) - (1 << unused_bits);

--- a/third-party/LibRaw/src/utils/phaseone_processing.cpp
+++ b/third-party/LibRaw/src/utils/phaseone_processing.cpp
@@ -27,7 +27,7 @@ void LibRaw::phase_one_allocate_tempbuffer()
 		// Processed by RawSpeed, raw_image contains ptr to rawspeed internals
 		imgdata.rawdata.raw_alloc = imgdata.rawdata.raw_image; // save for data processing and future reuse
 	}
-    imgdata.rawdata.raw_image = (ushort *)malloc(S.raw_pitch * S.raw_height);
+    imgdata.rawdata.raw_image = (ushort *)malloc(UINT64(S.raw_pitch) * UINT64(S.raw_height));
 }
 void LibRaw::phase_one_free_tempbuffer()
 {

--- a/third-party/LibRaw/src/utils/read_utils.cpp
+++ b/third-party/LibRaw/src/utils/read_utils.cpp
@@ -159,10 +159,10 @@ double libraw_sgetreal_static(short _order, int type, uchar *s)
   case LIBRAW_EXIFTAG_TYPE_DOUBLE:
     rev = 7 * ((_order == 0x4949) == (ntohs(0x1234) == 0x1234));
     for (i = 0; i < 8; i++)
-      u.c[i ^ rev] = *(s+1);
+      u.c[i ^ rev] = *(s+i);
     return u.d;
   default:
-    return *(s+1);
+    return *s;
   }
 }
 

--- a/third-party/LibRaw/src/utils/thumb_utils.cpp
+++ b/third-party/LibRaw/src/utils/thumb_utils.cpp
@@ -254,7 +254,6 @@ void LibRaw::kodak_thumb_loader()
   libraw_internal_data.unpacker_data.load_flags = s_flags;
 }
 
-// ������� thumbnail �� �����, ������ thumb_format � ������������ � ��������
 
 int LibRaw::thumbOK(INT64 maxsz)
 {

--- a/third-party/LibRaw/src/write/file_write.cpp
+++ b/third-party/LibRaw/src/write/file_write.cpp
@@ -144,7 +144,7 @@ void LibRaw::jpeg_thumb_writer(FILE *tfp, char *t_humb, int t_humb_length)
   struct tiff_hdr th;
   fputc(0xff, tfp);
   fputc(0xd8, tfp);
-  if (strcmp(t_humb + 6, "Exif"))
+  if (memcmp(t_humb + 6, "Exif\0",5))
   {
     memcpy(exif, "\xff\xe1  Exif\0\0", 10);
     exif[1] = htons(8 + sizeof th);

--- a/third-party/LibRaw/src/x3f/x3f_parse_process.cpp
+++ b/third-party/LibRaw/src/x3f/x3f_parse_process.cpp
@@ -152,13 +152,13 @@ void LibRaw::parse_x3f()
         if (!strcmp(name, "ISO"))
           imgdata.other.iso_speed = float(atoi(value));
         if (!strcmp(name, "CAMMANUF"))
-          strcpy(imgdata.idata.make, value);
+          strncpy(imgdata.idata.make, value, sizeof(imgdata.idata.make)-1);
         if (!strcmp(name, "CAMMODEL"))
-          strcpy(imgdata.idata.model, value);
+          strncpy(imgdata.idata.model, value, sizeof(imgdata.idata.model) - 1);
         if (!strcmp(name, "CAMSERIAL"))
-          strcpy(imgdata.shootinginfo.BodySerial, value);
+          strncpy(imgdata.shootinginfo.BodySerial, value, sizeof(imgdata.shootinginfo.BodySerial) - 1);
         if (!strcmp(name, "WB_DESC"))
-          strcpy(imgdata.color.model2, value);
+          strncpy(imgdata.color.model2, value, sizeof(imgdata.color.model2) - 1);
         if (!strcmp(name, "TIME"))
           imgdata.other.timestamp = atoi(value);
         if (!strcmp(name, "SHUTTER"))

--- a/third-party/LibRaw/src/x3f/x3f_utils_patched.cpp
+++ b/third-party/LibRaw/src/x3f/x3f_utils_patched.cpp
@@ -1152,14 +1152,21 @@ static int32_t get_simple_diff(x3f_huffman_t *HUF, uint16_t index)
 }
 
 static void simple_decode_row(x3f_info_t * /*I*/, x3f_directory_entry_t *DE,
-                              int bits, int row, int row_stride)
+                              int bits, int row, uint32_t row_stride)
 {
   x3f_directory_entry_header_t *DEH = &DE->header;
   x3f_image_data_t *ID = &DEH->data_subsection.image_data;
   x3f_huffman_t *HUF = ID->huffman;
 
-  if (row*row_stride > (int)(ID->data_size - (ID->columns*sizeof(uint32_t))))
-	  throw LIBRAW_EXCEPTION_IO_CORRUPT;
+  // 64bit compute to avoid 32 bit overflow
+  uint64_t needed = uint64_t(ID->columns) * sizeof(uint32_t);
+  uint64_t offset = uint64_t(row) * uint64_t(row_stride);
+
+  if (row_stride < needed)
+    throw LIBRAW_EXCEPTION_IO_CORRUPT;
+  if (offset > uint64_t(ID->data_size) || needed > uint64_t(ID->data_size) - offset)
+    throw LIBRAW_EXCEPTION_IO_CORRUPT;
+
   uint32_t *data = (uint32_t *)((unsigned char *)ID->data + row * row_stride);
 
   uint16_t c[3] = {0, 0, 0};
@@ -1223,7 +1230,7 @@ static void simple_decode_row(x3f_info_t * /*I*/, x3f_directory_entry_t *DE,
 }
 
 static void simple_decode(x3f_info_t *I, x3f_directory_entry_t *DE, int bits,
-                          int row_stride)
+                          uint32_t row_stride)
 {
   x3f_directory_entry_header_t *DEH = &DE->header;
   x3f_image_data_t *ID = &DEH->data_subsection.image_data;
@@ -1401,7 +1408,12 @@ static void x3f_load_true(x3f_info_t *I, x3f_directory_entry_t *DE)
     TRU->x3rgb16.rows = rows;
     TRU->x3rgb16.channels = channels;
     TRU->x3rgb16.row_stride = columns * channels;
-    TRU->x3rgb16.buf = x3f_limited_malloc(sizeof(uint16_t) * size);
+    TRU->x3rgb16.buf =
+#ifdef LIBRAW_CALLOC_RAWSTORE
+        x3f_limited_calloc(sizeof(uint16_t) * size, 1);
+#else
+		x3f_limited_malloc(sizeof(uint16_t) * size);
+#endif
     TRU->x3rgb16.data = (uint16_t *)TRU->x3rgb16.buf;
 
     columns = Q->plane[2].columns;
@@ -1413,7 +1425,12 @@ static void x3f_load_true(x3f_info_t *I, x3f_directory_entry_t *DE)
     Q->top16.rows = rows;
     Q->top16.channels = channels;
     Q->top16.row_stride = columns * channels;
-    Q->top16.buf = x3f_limited_malloc(sizeof(uint16_t) * size);
+    Q->top16.buf =
+#ifdef LIBRAW_CALLOC_RAWSTORE
+        x3f_limited_calloc(sizeof(uint16_t) * size, 1);
+#else
+        x3f_limited_malloc(sizeof(uint16_t) * size);
+#endif
     Q->top16.data = (uint16_t *)Q->top16.buf;
   }
   else
@@ -1424,7 +1441,12 @@ static void x3f_load_true(x3f_info_t *I, x3f_directory_entry_t *DE)
     TRU->x3rgb16.rows = ID->rows;
     TRU->x3rgb16.channels = 3;
     TRU->x3rgb16.row_stride = ID->columns * 3;
-    TRU->x3rgb16.buf = x3f_limited_malloc(sizeof(uint16_t) * size);
+    TRU->x3rgb16.buf =
+#ifdef LIBRAW_CALLOC_RAWSTORE
+        x3f_limited_calloc(sizeof(uint16_t) * size, 1);
+#else
+        x3f_limited_malloc(sizeof(uint16_t) * size);
+#endif
     TRU->x3rgb16.data = (uint16_t *)TRU->x3rgb16.buf;
   }
 
@@ -1456,7 +1478,7 @@ static void x3f_load_huffman_compressed(x3f_info_t *I,
 
 static void x3f_load_huffman_not_compressed(x3f_info_t *I,
                                             x3f_directory_entry_t *DE, int bits,
-                                            int /*use_map_table*/, int row_stride)
+                                            int /*use_map_table*/, uint32_t row_stride)
 {
   x3f_directory_entry_header_t *DEH = &DE->header;
   x3f_image_data_t *ID = &DEH->data_subsection.image_data;
@@ -1468,7 +1490,7 @@ static void x3f_load_huffman_not_compressed(x3f_info_t *I,
 }
 
 static void x3f_load_huffman(x3f_info_t *I, x3f_directory_entry_t *DE, int bits,
-                             int use_map_table, int row_stride)
+                             int use_map_table, uint32_t row_stride)
 {
   x3f_directory_entry_header_t *DEH = &DE->header;
   x3f_image_data_t *ID = &DEH->data_subsection.image_data;
@@ -1491,7 +1513,12 @@ static void x3f_load_huffman(x3f_info_t *I, x3f_directory_entry_t *DE, int bits,
     HUF->x3rgb16.rows = ID->rows;
     HUF->x3rgb16.channels = 3;
     HUF->x3rgb16.row_stride = ID->columns * 3;
-    HUF->x3rgb16.buf = x3f_limited_malloc(sizeof(uint16_t) * size);
+    HUF->x3rgb16.buf =
+#ifdef LIBRAW_CALLOC_RAWSTORE
+        x3f_limited_calloc(sizeof(uint16_t) * size, 1);
+#else
+        x3f_limited_malloc(sizeof(uint16_t) * size);
+#endif
     HUF->x3rgb16.data = (uint16_t *)HUF->x3rgb16.buf;
     break;
   case X3F_IMAGE_THUMB_HUFFMAN:
@@ -1500,7 +1527,12 @@ static void x3f_load_huffman(x3f_info_t *I, x3f_directory_entry_t *DE, int bits,
     HUF->rgb8.rows = ID->rows;
     HUF->rgb8.channels = 3;
     HUF->rgb8.row_stride = ID->columns * 3;
-    HUF->rgb8.buf = x3f_limited_malloc(sizeof(uint8_t) * size);
+    HUF->rgb8.buf =
+#ifdef LIBRAW_CALLOC_RAWSTORE
+        x3f_limited_calloc(sizeof(uint8_t) * size, 1);
+#else
+		x3f_limited_malloc(sizeof(uint8_t) * size);
+#endif
     HUF->rgb8.data = (uint8_t *)HUF->rgb8.buf;
     break;
   default:
@@ -1600,7 +1632,7 @@ static void x3f_load_camf_decode_type2(x3f_camf_t *CAMF)
   int i;
 
   CAMF->decoded_data_size = CAMF->data_size;
-  CAMF->decoded_data = x3f_limited_malloc(CAMF->decoded_data_size);
+  CAMF->decoded_data = x3f_limited_calloc(CAMF->decoded_data_size, 1);
 
   for (i = 0; i < (int)CAMF->data_size; i++)
   {
@@ -1641,7 +1673,7 @@ static void camf_decode_type4(x3f_camf_t *CAMF)
 
   CAMF->decoded_data_size = dst_size;
 
-  CAMF->decoded_data = x3f_limited_malloc(CAMF->decoded_data_size);
+  CAMF->decoded_data = x3f_limited_calloc(CAMF->decoded_data_size, 1);
   memset(CAMF->decoded_data, 0, CAMF->decoded_data_size);
 
   dst = (uint8_t *)CAMF->decoded_data;
@@ -1761,7 +1793,7 @@ static void camf_decode_type5(x3f_camf_t *CAMF)
   int32_t i;
 
   CAMF->decoded_data_size = CAMF->t5.decoded_data_size;
-  CAMF->decoded_data = x3f_limited_malloc(CAMF->decoded_data_size);
+  CAMF->decoded_data = x3f_limited_calloc(CAMF->decoded_data_size, 1);
 
   dst = (uint8_t *)CAMF->decoded_data;
 
@@ -1828,8 +1860,8 @@ static void x3f_setup_camf_property_entry(camf_entry_t *entry)
   uint32_t num = entry->property_num = *(uint32_t *)v;
   uint32_t off = *(uint32_t *)(v + 4);
 
-  entry->property_name = (char **)x3f_limited_malloc(num * sizeof(uint8_t *));
-  entry->property_value = (uint8_t **)x3f_limited_malloc(num * sizeof(uint8_t *));
+  entry->property_name = (char **)x3f_limited_calloc(num * sizeof(uint8_t *), 1);
+  entry->property_value = (uint8_t **)x3f_limited_calloc(num * sizeof(uint8_t *), 1);
 
   for (i = 0; i < (int)num; i++)
   {


### PR DESCRIPTION
## Summary

- update vendored LibRaw from 0.22.1 to 0.22.2
- use the already-integrated `release/1.27.0` vendor snapshot
- leave the independent 1.27 `files_raw.cpp` behavior and refactoring changes out of the 1.26 update

## Validation

- forced x64 Release rebuild of LibRaw: 0 errors, 77 existing macro-redefinition warnings
- x64 Release solution build/relink: 0 errors
- x64 embedded tests: 344 passed / 0 failed
- forced Win32 Release rebuild of LibRaw: 0 errors, 77 existing macro-redefinition warnings
- Win32 Release solution build/link: 0 errors
- verified `third-party/LibRaw` exactly matches `release/1.27.0`
- verified no tracked changes outside `third-party/LibRaw`

## Notes

The Win32 link retains two existing `LNK4020` PDB type-record warnings. `git diff --check` also reports six trailing-space lines already present in the upstream LibRaw 0.22.2 snapshot; they are preserved intentionally so the vendored source remains byte-for-byte identical to the validated 1.27 copy.