### PR TITLE
Fix 32-bit MSVC stack alignment in FFmpeg x86 asm; bump to 1.27.0.1270

### DIFF
--- a/installer/diff.nsi
+++ b/installer/diff.nsi
@@ -4,7 +4,7 @@
 !define PRODUCT32_EXE "diffractor32.exe"
 !define PRODUCT64_EXE "diffractor64.exe"
 !define PRODUCT_PUBLISHER "Diffractor"
-!define BUILD_NUM "1269"
+!define BUILD_NUM "1270"
 !define PRODUCT_VERSION "127.0"
 !define FILE_VERSION "1.27.0.${BUILD_NUM}"
 !define PRODUCT_WEB_SITE "http://www.Diffractor.com/"

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -51,7 +51,7 @@ command_line_t command_line;
 auto s_app_name_l = L"Diffractor";
 const std::string_view s_app_name = "Diffractor";
 const std::string_view s_app_version = "127.0";
-const std::string_view g_app_build = "1269";
+const std::string_view g_app_build = "1270";
 static constexpr auto s_search = "search";
 
 extern void start_worker(platform::task_queue& q, std::string_view name);

--- a/src/platform_win.manifest
+++ b/src/platform_win.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity
       type="win32"
       name="diffractor.exe"
-      version="1.27.0.1269"
+      version="1.27.0.1270"
       processorArchitecture="*"
     />
   <asmv3:application>

--- a/src/platform_win_res.rc
+++ b/src/platform_win_res.rc
@@ -146,8 +146,8 @@ IDR_MANIFEST            RT_MANIFEST             "platform_win.manifest"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1, 27, 0, 1269
- PRODUCTVERSION 1, 27, 0, 1269
+ FILEVERSION 1, 27, 0, 1270
+ PRODUCTVERSION 1, 27, 0, 1270
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -164,12 +164,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Diffractor"
             VALUE "FileDescription", "Diffractor"
-            VALUE "FileVersion", "1.27.0.1269"
+            VALUE "FileVersion", "1.27.0.1270"
             VALUE "InternalName", "Diffractor.exe"
             VALUE "LegalCopyright", "Copyright (C) 2024 Diffractor - Zac Walker"
             VALUE "OriginalFilename", "Diffractor.exe"
             VALUE "ProductName", "Diffractor"
-            VALUE "ProductVersion", "1.27.0.1269"
+            VALUE "ProductVersion", "1.27.0.1270"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
FFmpeg's x86 assembly assumed a 16-byte aligned stack, which the 32-bit MSVC ABI does not guarantee. The `third-party/FFmpeg` submodule now points at the build configuration that drops that assumption (`diffractor/FFmpeg@36a86e7`, on `rebase/upstream-8.0`).

Also bumps the build number to `1.27.0.1270` across `installer/diff.nsi`, `src/app.cpp`, `src/platform_win.manifest`, and `src/platform_win_res.rc`.

Branched directly off `master` so it applies cleanly. The same commit is on `release/1.27.0` as `f4c3383d`, and the resulting trees on both branches are identical.

Supersedes #245, which conflicted only because `release/1.27.0` predates the squashed `Release 1.27.0 (#239)` merge.